### PR TITLE
Fixed Welcome, undefined! when on homepage without a name

### DIFF
--- a/components/account/Landing.tsx
+++ b/components/account/Landing.tsx
@@ -22,7 +22,7 @@ export default function Landing() {
           />
         </div>
         {session ? (
-          <h2>{`Welcome, ${session.user?.firstName}!`}</h2>
+          <h2>{session.user?.firstName ? `Welcome, ${session.user?.firstName}!` : `Welcome!`}</h2>
         ) : (
           <h2>Illawarra Multicultural Services</h2>
         )}


### PR DESCRIPTION
Resolves #34, now it just has Welcome! if there is no first name. 

<img width="864" alt="image" src="https://user-images.githubusercontent.com/80566196/162872299-11149580-6c3d-499d-aa6e-f799d55ac89c.png">
