### PR TITLE
Add Stripe Publishable Key Env Var

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_STRIPE_PK=pk_test_51IyV4OFAD84FX6wfbxzuc1uNnh41w0BfoHKLumVTzCXzUSxFG6S5fly3Ry1Xl0kmpb8JoJD5IriwjC0cDO2Zf49W00NE4Gmy9S
+NEXT_PUBLIC_API_URL="https://migram.herokuapp.com/"
+NEXTAUTH_URL="http://localhost:3000/"

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -9,6 +9,7 @@
 
 ```
 NEXT_PUBLIC_API_URL="https://migram.herokuapp.com/"
+NEXT_PUBLIC_STRIPE_PK=pk_test_51Ldv3lIDyogLrEpF26RGnjQqJAQYZHaBahJEGwGox2ygfgv973VyI3yW0TOboRQ8HOPbZwnMaqJ3xzKWquv2zt6C00n535N91v
 NEXTAUTH_URL="http://localhost:3000/"
 ```
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,10 +12,7 @@ Router.events.on("routeChangeStart", () => Nprogress.start());
 Router.events.on("routeChangeComplete", () => Nprogress.done());
 Router.events.on("routeChangeError", () => Nprogress.done());
 
-const stripePromise = loadStripe(
-  "pk_test_51IyV4OFAD84FX6wfbxzuc1uNnh41w0BfoHKLumVTzCXzUSxFG6S5fly3Ry1Xl0kmpb8JoJD5IriwjC0cDO2Zf49W00NE4Gmy9S "
-);
-console.log(`${process.env.STRIPE_PUBLISHABLE_KEY}`);
+const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PK as string);
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
Add Stripe Publishable Key Env Variable to allow for the developer to use their own Stripe account for local testing.

Fixes #74 

You'll need to add this as an environment variable to the Vercel deployment for the changes to work.

`NEXT_PUBLIC_STRIPE_PK=pk_test_51IyV4OFAD84FX6wfbxzuc1uNnh41w0BfoHKLumVTzCXzUSxFG6S5fly3Ry1Xl0kmpb8JoJD5IriwjC0cDO2Zf49W00NE4Gmy9S`