### PR TITLE
fix: 83 Hide Confirm Payment Button

### DIFF
--- a/src/components/tasks/TaskDetails/TaskDetails.tsx
+++ b/src/components/tasks/TaskDetails/TaskDetails.tsx
@@ -183,7 +183,7 @@ export default function TaskDetails({ selectedTask }: any) {
     selectedTask && (
       <>
         {updatedTask?.status == "completed" && isMyTask && (
-          <ButtonStyles onClick={handleReleasePayment} fullWidth>
+          <ButtonStyles onClick={handleReleasePayment} fullWidth hidden>
             Confirm Payment
           </ButtonStyles>
         )}


### PR DESCRIPTION
Temporarily hides the confirm payment button as payments have been disabled until after the soft-launch

fixes #83