### PR TITLE
fix: 80 Hide "Post a Job" Button If Not Logged In

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -47,7 +47,7 @@ const Home: NextPage = () => {
         </p>
         <div className="flex-container">
           <Link href="/tasks/createtask" passHref>
-            <ButtonStyles>Post a Job</ButtonStyles>
+            <ButtonStyles hidden={!session?.user}>Post a Job</ButtonStyles>
           </Link>
           {/* Commented by Engramar 24/08/2022     
             <ButtonStyles primary>Get started</ButtonStyles>


### PR DESCRIPTION
Hides the "Post a Job" button when the user is not logged in.

fixes: #80

## Before
### Not Logged In
![image](https://user-images.githubusercontent.com/8443215/193795656-b295e711-1b44-4ebb-948c-7c2b37e1aff5.png)

## After
### Not Logged In
![image](https://user-images.githubusercontent.com/8443215/193795533-ad1509d8-3ec6-4efe-ac3b-9efdfb506aa4.png)

### Logged In
![image](https://user-images.githubusercontent.com/8443215/193795574-b386907e-34a8-4db5-a285-fba997b180be.png)
