### PR TITLE
fix: broken login due to next-auth update to v4

### DIFF
--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -34,6 +34,7 @@ export default NextAuth({
       },
     }),
   ],
+  secret: process.env.NEXTAUTH_SECRET,
   callbacks: {
     async jwt({ token, user }) {
       if (user) {


### PR DESCRIPTION
next-auth v4 will throw an error if NEXTAUTH_SECRET is not provided.

See: https://next-auth.js.org/configuration/options#secret