### PR TITLE
Set JWT as default axios header

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -11,6 +11,8 @@ import ButtonStyles from "../components/styles/ButtonStyles";
 import FormStyles from "../components/styles/FormStyles";
 import { validate } from "../lib/validator";
 import useForm from "../lib/useForm";
+import axios from "axios";
+import { getSession } from "next-auth/react";
 
 const LoginPage: NextPage = () => {
   const router = useRouter();
@@ -31,6 +33,13 @@ const LoginPage: NextPage = () => {
       redirect: false,
       callbackUrl: "/",
     });
+
+    const session = await getSession();
+
+    axios.defaults.headers.common[
+      "authorization"
+    ] = `Bearer ${session?.accessToken}`;
+
     setLoading(false);
     if (data?.url) {
       resetForm();


### PR DESCRIPTION
Set JWT as the default auth header for all axios requests. 

Fixes [#105](https://github.com/codesydney/migram-frontend/issues/105)