### PR TITLE
refactor: remove default Auth header upon signout

### DIFF
--- a/src/components/common/UserIcon.tsx
+++ b/src/components/common/UserIcon.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import Image from "next/legacy/image";
 import { useSession, signOut } from "next-auth/react";
+import axios from "axios";
 import styled from "styled-components";
 
 import UserIconStyles from "../styles/UserIconStyles";
@@ -29,6 +30,7 @@ export default function UserIcon(props: any) {
     e.preventDefault();
     const data: any = await signOut({ redirect: false, callbackUrl: "/login" });
     if (data.url) {
+      delete axios.defaults.headers.common["Authorization"];
       router.push(data.url);
     }
   }


### PR DESCRIPTION
Removes the default `Authorization` header when the user signs out.

Context:
The LoginPage sets a default header when the user logs in.