### PR TITLE
refactor: NavMenu sets JWT when user refreshes

### DIFF
--- a/src/components/common/Header/NavMenu.tsx
+++ b/src/components/common/Header/NavMenu.tsx
@@ -1,9 +1,10 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, useEffect } from "react";
 import { useSession } from "next-auth/react";
 import styled from "styled-components";
 
 import UserIcon from "../UserIcon";
 import { NavItems } from "./NavItems";
+import axios from "axios";
 
 const StyledNavMenu = styled.ul`
   margin: 0;
@@ -55,6 +56,14 @@ export const NavMenu = ({
   setHamburgerActive,
 }: StyledNavMenuProps) => {
   const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session && !axios.defaults.headers.common["authorization"]) {
+      axios.defaults.headers.common[
+        "authorization"
+      ] = `Bearer ${session?.accessToken}`;
+    }
+  }, [session]);
 
   const handleMenuItemClick = () => {
     setHamburgerActive(false);


### PR DESCRIPTION
This fixes an issue when requests after the user refreshes their browser return HTTP 401. This is caused by the JWT is not being saved as the axios default 'Authorization' header.