### PR TITLE
feat: protect /tasks and /offers page

### DIFF
--- a/src/pages/offers.tsx
+++ b/src/pages/offers.tsx
@@ -1,8 +1,28 @@
 import { useSession } from "next-auth/react";
+import { Card, EmptyState, Layout, Page } from "@shopify/polaris";
 
 import { ViewOffersPage } from "@Tasks/ViewOffers/components/ViewOffersPage";
 
 export default function OffersPage() {
-  const { status } = useSession();
+  const { status, data } = useSession();
+
+  if (data?.user.customerId) {
+    return (
+      <Page title="Offers" fullWidth>
+        <Layout>
+          <Layout.Section>
+            <Card sectioned>
+              <EmptyState
+                heading="This Page is not available for customers."
+                image={""}
+                action={{ content: "Go to Home", url: "/" }}
+              />
+            </Card>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  }
+
   return <ViewOffersPage status={status} />;
 }

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -8,7 +8,7 @@ export default function TasksPage() {
 
   if (data?.user.providerId) {
     return (
-      <Page title="Offers" fullWidth>
+      <Page title="Tasks" fullWidth>
         <Layout>
           <Layout.Section>
             <Card sectioned>

--- a/src/pages/tasks/index.tsx
+++ b/src/pages/tasks/index.tsx
@@ -1,8 +1,28 @@
-import { TasksPage as TaskPagePrimitive } from "@Tasks/ViewTasks";
 import { useSession } from "next-auth/react";
+import { Card, EmptyState, Layout, Page } from "@shopify/polaris";
+
+import { TasksPage as TaskPagePrimitive } from "@Tasks/ViewTasks";
 
 export default function TasksPage() {
-  const { status } = useSession();
+  const { status, data } = useSession();
+
+  if (data?.user.providerId) {
+    return (
+      <Page title="Offers" fullWidth>
+        <Layout>
+          <Layout.Section>
+            <Card sectioned>
+              <EmptyState
+                heading="This Page is not available for providers."
+                image={""}
+                action={{ content: "Go to Home", url: "/" }}
+              />
+            </Card>
+          </Layout.Section>
+        </Layout>
+      </Page>
+    );
+  }
 
   return <TaskPagePrimitive status={status} />;
-};
+}


### PR DESCRIPTION
Protect `/tasks` from being accessed by Service Providers, and protect `/offers` from being accessed by Customers

Closes #147 

## Screenshots

**Offers Page when the User is a Customer**
![image](https://user-images.githubusercontent.com/8443215/218072750-d8062bcf-76d1-4394-8206-5e53b147126d.png)

**Tasks Page when the User is a Service Provider**
![Screenshot from 2023-02-10 21-39-44](https://user-images.githubusercontent.com/8443215/218072227-33f8391c-e4ca-48ac-91fb-3f66a92bed84.png)
