### PR TITLE
feat: createApiResponse

### DIFF
--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -1,14 +1,19 @@
 import { AxiosResponse } from "axios";
 import { ApiResponse } from "./types";
 
-export function createApiResponse(result: AxiosResponse): ApiResponse<any> {
+export function createApiResponse(
+  result: AxiosResponse,
+  successMessage: string
+): ApiResponse<any> {
+  const isError = result.status !== 200;
+
   return {
     apiEvent: {
-      isError: result.status !== 200,
-      title: result.data.message,
+      isError,
+      title: isError ? result.data.message : successMessage,
       status: result.status,
       statusText: result.statusText,
     },
-    data: undefined,
+    data: isError ? undefined : result.data,
   };
 }

--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -5,7 +5,7 @@ export function createApiResponse(
   result: AxiosResponse,
   successMessage: string
 ): ApiResponse<any> {
-  const isError = result.status !== 200;
+  const isError = Math.trunc(result.status / 100) !== 2;
 
   return {
     apiEvent: {

--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -1,11 +1,13 @@
 import { AxiosResponse } from "axios";
+
 import { ApiResponse } from "./types";
+import { isErrorStatusCode } from "./utils";
 
 export function createApiResponse(
   result: AxiosResponse,
   successMessage: string
 ): ApiResponse<any> {
-  const isError = Math.trunc(result.status / 100) !== 2;
+  const isError = isErrorStatusCode(result.status);
 
   return {
     apiEvent: {

--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse } from "axios";
+import { ApiResponse } from "./types";
+
+export function createApiResponse(result: AxiosResponse): ApiResponse<any> {
+  return {
+    apiEvent: {
+      isError: result.status !== 200,
+      title: result.data.message,
+      status: result.status,
+      statusText: result.statusText,
+    },
+    data: undefined,
+  };
+}

--- a/src/common/ApiResponse/index.ts
+++ b/src/common/ApiResponse/index.ts
@@ -1,0 +1,2 @@
+export * from "./types";
+export * from "./createApiResponse";

--- a/src/common/ApiResponse/tests/createApiResponse.test.ts
+++ b/src/common/ApiResponse/tests/createApiResponse.test.ts
@@ -5,22 +5,99 @@ import { ApiResponse } from "../types";
 type AxiosTableTestCases = {
   name: string;
   input: AxiosResponse;
+  successMessage: string;
   expected: ApiResponse<any>;
 }[];
 
+const Axios200Response_GetOffersList: AxiosResponse = {
+  data: {
+    status: "success",
+    results: 1,
+    data: {
+      offers: [
+        {
+          status: "completed",
+          _id: "6360610f5fac2e5082d00912",
+          offerAmt: 195,
+          comments: "waerawerawerw123123123123123",
+          providerId: "acct_1Lur4rIWxYvLVjGY",
+          task: "636060fa5fac2e5082d00903",
+          createdAt: "2022-10-31T23:58:07.185Z",
+          updatedAt: "2022-11-06T09:28:04.710Z",
+          __v: 0,
+          timeElapsed: "115 days ago",
+          id: "6360610f5fac2e5082d00912",
+        },
+      ],
+    },
+  },
+  status: 200,
+  statusText: "OK",
+  headers: {},
+  config: {},
+};
+
+const Axios401Response: AxiosResponse = {
+  data: {
+    status: "error",
+    message: "Invalid Token: please log in again.",
+  },
+  status: 401,
+  statusText: "Unauthorized",
+  headers: {},
+  config: {},
+};
+
+const Axios500Response: AxiosResponse = {
+  data: {
+    status: "error",
+    message: "Invalid Task",
+  },
+  status: 500,
+  statusText: "Internal Server Error",
+  headers: {},
+  config: {},
+};
+
 const axiosTestCases: AxiosTableTestCases = [
   {
-    name: "handles 401 Unauthorized Axios Error Response",
-    input: {
-      data: {
-        status: "error",
-        message: "Invalid Token: please log in again.",
+    name: "handles 200 OK Axios Response",
+    input: Axios200Response_GetOffersList,
+    successMessage: "Successfully loaded Offers.",
+    expected: {
+      apiEvent: {
+        isError: false,
+        title: "Successfully loaded Offers.",
+        status: 200,
+        statusText: "OK",
       },
-      status: 401,
-      statusText: "Unauthorized",
-      headers: {},
-      config: {},
+      data: {
+        status: "success",
+        results: 1,
+        data: {
+          offers: [
+            {
+              status: "completed",
+              _id: "6360610f5fac2e5082d00912",
+              offerAmt: 195,
+              comments: "waerawerawerw123123123123123",
+              providerId: "acct_1Lur4rIWxYvLVjGY",
+              task: "636060fa5fac2e5082d00903",
+              createdAt: "2022-10-31T23:58:07.185Z",
+              updatedAt: "2022-11-06T09:28:04.710Z",
+              __v: 0,
+              timeElapsed: "115 days ago",
+              id: "6360610f5fac2e5082d00912",
+            },
+          ],
+        },
+      },
     },
+  },
+  {
+    name: "handles 401 Unauthorized Axios Error Response",
+    input: Axios401Response,
+    successMessage: "Successfully loaded Offers.",
     expected: {
       apiEvent: {
         isError: true,
@@ -33,16 +110,8 @@ const axiosTestCases: AxiosTableTestCases = [
   },
   {
     name: "handles 500 Internal Server Error Axios Response",
-    input: {
-      data: {
-        status: "error",
-        message: "Invalid Task",
-      },
-      status: 500,
-      statusText: "Internal Server Error",
-      headers: {},
-      config: {},
-    },
+    input: Axios500Response,
+    successMessage: "Successfully loaded Task.",
     expected: {
       apiEvent: {
         isError: true,
@@ -55,8 +124,8 @@ const axiosTestCases: AxiosTableTestCases = [
   },
 ];
 
-it.each(axiosTestCases)("$name", ({ name, input, expected }) => {
-  const actual = createApiResponse(input);
+it.each(axiosTestCases)("$name", ({ input, successMessage, expected }) => {
+  const actual = createApiResponse(input, successMessage);
 
   expect(actual).toEqual(expected);
 });

--- a/src/common/ApiResponse/tests/createApiResponse.test.ts
+++ b/src/common/ApiResponse/tests/createApiResponse.test.ts
@@ -37,6 +37,31 @@ const Axios200Response_GetOffersList: AxiosResponse = {
   config: {},
 };
 
+const Axios201Response_CreateOffer: AxiosResponse = {
+  data: {
+    status: "success",
+    data: {
+      task: {
+        status: "open",
+        _id: "63f860b4250a0e93b760ef69",
+        offerAmt: 200,
+        comments: "Testing because I want the Axios Response",
+        providerId: "acct_1Lur4rIWxYvLVjGY",
+        task: "6350d7bc80c58772355d7625",
+        createdAt: "2023-02-24T07:01:08.013Z",
+        updatedAt: "2023-02-24T07:01:08.013Z",
+        __v: 0,
+        timeElapsed: "0 secs ago",
+        id: "63f860b4250a0e93b760ef69",
+      },
+    },
+  },
+  status: 201,
+  statusText: "Created",
+  headers: {},
+  config: {},
+};
+
 const Axios401Response: AxiosResponse = {
   data: {
     status: "error",
@@ -91,6 +116,37 @@ const axiosTestCases: AxiosTableTestCases = [
             },
           ],
         },
+      },
+    },
+  },
+  {
+    name: "handles 201 Created Axios Response",
+    input: Axios201Response_CreateOffer,
+    successMessage: "Successfully created Offer.",
+    expected: {
+      apiEvent: {
+        isError: false,
+        title: "Successfully created Offer.",
+        status: 201,
+        statusText: "Created",
+      },
+      data: {
+        data: {
+          task: {
+            status: "open",
+            _id: "63f860b4250a0e93b760ef69",
+            offerAmt: 200,
+            comments: "Testing because I want the Axios Response",
+            providerId: "acct_1Lur4rIWxYvLVjGY",
+            task: "6350d7bc80c58772355d7625",
+            createdAt: "2023-02-24T07:01:08.013Z",
+            updatedAt: "2023-02-24T07:01:08.013Z",
+            __v: 0,
+            timeElapsed: "0 secs ago",
+            id: "63f860b4250a0e93b760ef69",
+          },
+        },
+        status: "success",
       },
     },
   },

--- a/src/common/ApiResponse/tests/createApiResponse.test.ts
+++ b/src/common/ApiResponse/tests/createApiResponse.test.ts
@@ -1,0 +1,62 @@
+import { AxiosResponse } from "axios";
+import { createApiResponse } from "../createApiResponse";
+import { ApiResponse } from "../types";
+
+type AxiosTableTestCases = {
+  name: string;
+  input: AxiosResponse;
+  expected: ApiResponse<any>;
+}[];
+
+const axiosTestCases: AxiosTableTestCases = [
+  {
+    name: "handles 401 Unauthorized Axios Error Response",
+    input: {
+      data: {
+        status: "error",
+        message: "Invalid Token: please log in again.",
+      },
+      status: 401,
+      statusText: "Unauthorized",
+      headers: {},
+      config: {},
+    },
+    expected: {
+      apiEvent: {
+        isError: true,
+        title: "Invalid Token: please log in again.",
+        status: 401,
+        statusText: "Unauthorized",
+      },
+      data: undefined,
+    },
+  },
+  {
+    name: "handles 500 Internal Server Error Axios Response",
+    input: {
+      data: {
+        status: "error",
+        message: "Invalid Task",
+      },
+      status: 500,
+      statusText: "Internal Server Error",
+      headers: {},
+      config: {},
+    },
+    expected: {
+      apiEvent: {
+        isError: true,
+        title: "Invalid Task",
+        status: 500,
+        statusText: "Internal Server Error",
+      },
+      data: undefined,
+    },
+  },
+];
+
+it.each(axiosTestCases)("$name", ({ name, input, expected }) => {
+  const actual = createApiResponse(input);
+
+  expect(actual).toEqual(expected);
+});

--- a/src/common/ApiResponse/tests/createApiResponse.test.ts
+++ b/src/common/ApiResponse/tests/createApiResponse.test.ts
@@ -63,11 +63,11 @@ const axiosTestCases: AxiosTableTestCases = [
   {
     name: "handles 200 OK Axios Response",
     input: Axios200Response_GetOffersList,
-    successMessage: "Successfully loaded Offers.",
+    successMessage: "Successfully loaded Offers list.",
     expected: {
       apiEvent: {
         isError: false,
-        title: "Successfully loaded Offers.",
+        title: "Successfully loaded Offers list.",
         status: 200,
         statusText: "OK",
       },

--- a/src/common/ApiResponse/tests/utils/isErrorStatusCode.test.ts
+++ b/src/common/ApiResponse/tests/utils/isErrorStatusCode.test.ts
@@ -1,0 +1,17 @@
+import { isErrorStatusCode } from "../../utils";
+
+type TestCases = { code: number; expected: boolean }[];
+
+const testCases: TestCases = [
+  { code: 200, expected: false },
+  { code: 201, expected: false },
+  { code: 204, expected: false },
+  { code: 400, expected: true },
+  { code: 401, expected: true },
+  { code: 403, expected: true },
+  { code: 500, expected: true },
+];
+
+it.each(testCases)("returns $expected for HTTP $code", ({ code, expected }) => {
+  expect(isErrorStatusCode(code)).toBe(expected);
+});

--- a/src/common/ApiResponse/tests/utils/isErrorStatusCode.test.ts
+++ b/src/common/ApiResponse/tests/utils/isErrorStatusCode.test.ts
@@ -3,9 +3,13 @@ import { isErrorStatusCode } from "../../utils";
 type TestCases = { code: number; expected: boolean }[];
 
 const testCases: TestCases = [
+  { code: 102, expected: false },
   { code: 200, expected: false },
   { code: 201, expected: false },
   { code: 204, expected: false },
+  { code: 300, expected: false },
+  { code: 304, expected: false },
+  { code: 308, expected: false },
   { code: 400, expected: true },
   { code: 401, expected: true },
   { code: 403, expected: true },

--- a/src/common/ApiResponse/types.ts
+++ b/src/common/ApiResponse/types.ts
@@ -1,0 +1,11 @@
+export type ApiEvent = {
+  isError: boolean;
+  title: string;
+  status: number;
+  statusText: string;
+};
+
+export type ApiResponse<TData> = {
+  apiEvent: ApiEvent;
+  data?: TData;
+};

--- a/src/common/ApiResponse/utils.ts
+++ b/src/common/ApiResponse/utils.ts
@@ -1,0 +1,3 @@
+export function isErrorStatusCode(statusCode: number) {
+  return Math.trunc(statusCode / 100) !== 2;
+}

--- a/src/common/ApiResponse/utils.ts
+++ b/src/common/ApiResponse/utils.ts
@@ -1,3 +1,4 @@
 export function isErrorStatusCode(statusCode: number) {
-  return Math.trunc(statusCode / 100) !== 2;
+  const firstDigit = Math.trunc(statusCode / 100);
+  return firstDigit === 4 || firstDigit === 5;
 }


### PR DESCRIPTION
This feature translates Axios responses to an ApiResponse which will be used to generate UI Toasts & Notifications.

- add `ApiEvent `& `ApiResponse` type definitions
- add `createApiResponse` function
- add `isStatusCode` util function