### PR TITLE
feat: add ApiEventsContext

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@stripe/stripe-js": "^1.19.1",
         "@tanstack/react-query": "^4.14.5",
         "axios": "^1.1.3",
+        "map-immute": "^0.2.1",
         "next": "^13.0.2",
         "next-auth": "^4.16.3",
         "nprogress": "^0.2.0",
@@ -9618,6 +9619,11 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-immute": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/map-immute/-/map-immute-0.2.1.tgz",
+      "integrity": "sha512-HNboGJmLjCUXpANerwA/lTxw3byTCDIrv9lCJHAlV5K4EEVWSBsWbFF06CRy8X6UF2mViZ+wVjlTA8vhVchNAw=="
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -19186,6 +19192,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "map-immute": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/map-immute/-/map-immute-0.2.1.tgz",
+      "integrity": "sha512-HNboGJmLjCUXpANerwA/lTxw3byTCDIrv9lCJHAlV5K4EEVWSBsWbFF06CRy8X6UF2mViZ+wVjlTA8vhVchNAw=="
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@stripe/stripe-js": "^1.19.1",
     "@tanstack/react-query": "^4.14.5",
     "axios": "^1.1.3",
+    "map-immute": "^0.2.1",
     "next": "^13.0.2",
     "next-auth": "^4.16.3",
     "nprogress": "^0.2.0",

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -1,17 +1,27 @@
 "use client";
 
-import { PropsWithChildren, createContext, useContext } from "react";
+import { PropsWithChildren, createContext, useContext, useState } from "react";
 import { ImmutableMap } from "map-immute";
 
 import { ApiEvent } from "./types";
 
 export type ApiEventsMap = ImmutableMap<string, ApiEvent>;
+export type ApiEventsContextValues = {
+  apiEvents: ApiEventsMap;
+  setApiEvents: (apiEvents: ApiEventsMap) => void;
+};
 
-const ApiEventsContext = createContext<ApiEventsMap | undefined>(undefined);
+const ApiEventsContext = createContext<ApiEventsContextValues | undefined>(
+  undefined
+);
 
 export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
+  const [apiEvents, setApiEvents] = useState<ApiEventsMap>(
+    () => new ImmutableMap<string, ApiEvent>()
+  );
+
   return (
-    <ApiEventsContext.Provider value={new ImmutableMap<string, ApiEvent>()}>
+    <ApiEventsContext.Provider value={{ apiEvents, setApiEvents }}>
       {children}
     </ApiEventsContext.Provider>
   );

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -1,0 +1,26 @@
+import { PropsWithChildren, createContext, useContext } from "react";
+import { ImmutableMap } from "map-immute";
+
+import { ApiEvent } from "./types";
+
+export type ApiEventsMap = ImmutableMap<string, ApiEvent>;
+
+const ApiEventsContext = createContext<ApiEventsMap | undefined>(undefined);
+
+export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
+  return (
+    <ApiEventsContext.Provider value={new ImmutableMap<string, ApiEvent>()}>
+      {children}
+    </ApiEventsContext.Provider>
+  );
+}
+
+export function useApiEvents() {
+  const context = useContext(ApiEventsContext);
+
+  if (!context) {
+    throw new Error("useApiEvents must be used within ApiEventsProvider");
+  }
+
+  return context;
+}

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { PropsWithChildren, createContext, useContext } from "react";
 import { ImmutableMap } from "map-immute";
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,6 +7,7 @@ import "nprogress/nprogress.css";
 
 import { ElementsWrapper } from "src/components/ElementsWrapper";
 import { Layout } from "src/components";
+import { ApiEventsProvider } from "src/common/ApiResponse/ApiEventsContext";
 
 if (process.env.NODE_ENV === "test") {
   require("../mocks");
@@ -21,13 +22,15 @@ const queryClient = new QueryClient();
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ElementsWrapper>
-      <SessionProvider session={pageProps.session}>
-        <QueryClientProvider client={queryClient}>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </QueryClientProvider>
-      </SessionProvider>
+      <ApiEventsProvider>
+        <SessionProvider session={pageProps.session}>
+          <QueryClientProvider client={queryClient}>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </QueryClientProvider>
+        </SessionProvider>
+      </ApiEventsProvider>
     </ElementsWrapper>
   );
 }


### PR DESCRIPTION
The `ApiEventsContext` uses the `ImmutableMap` to store a collection of `ApiEvents`. This setups the data structure for the upcoming `Notifications` feature.

Note: I wrote the `map-immute` package specifically for this purpose.