### PR TITLE
feat: Notifications [Proof of Concept]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@types/nprogress": "^0.2.0",
         "@types/react": "^17.0.22",
         "@types/styled-components": "^5.1.14",
+        "@types/uuid": "^9.0.1",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^29.2.2",
         "babel-plugin-styled-components": "^2.0.7",
@@ -3732,6 +3733,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -14922,6 +14929,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
       "dev": true
     },
     "@types/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-hook-form": "^7.39.1",
         "react-icons": "^4.4.0",
         "styled-components": "^5.3.1",
+        "uuid": "^9.0.0",
         "zod": "^3.20.2"
       },
       "devDependencies": {
@@ -9964,6 +9965,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/next-auth/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/next-router-mock": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.7.4.tgz",
@@ -11885,9 +11894,9 @@
       "dev": true
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -19420,6 +19429,11 @@
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
           "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw=="
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -20807,9 +20821,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/nprogress": "^0.2.0",
     "@types/react": "^17.0.22",
     "@types/styled-components": "^5.1.14",
+    "@types/uuid": "^9.0.1",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^29.2.2",
     "babel-plugin-styled-components": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-hook-form": "^7.39.1",
     "react-icons": "^4.4.0",
     "styled-components": "^5.3.1",
+    "uuid": "^9.0.0",
     "zod": "^3.20.2"
   },
   "devDependencies": {

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -53,38 +53,13 @@ const ApiEventsContext = createContext<ApiEventsContextValues | undefined>(
   undefined
 );
 
-const testEvents = [
-  [
-    "1",
-    {
-      id: "1",
-      isError: true,
-      title: "string",
-      status: 400,
-      statusText: "Bad Request",
-      level: "error",
-    },
-  ],
-  [
-    "2",
-    {
-      id: "2",
-      isError: true,
-      title: "Event Two",
-      status: 400,
-      statusText: "Bad Request",
-      level: "error",
-    },
-  ],
-] as const;
-
 export type ApiEventsProviderProps = {
   initialState?: ApiEventsMap;
 } & PropsWithChildren<{}>;
 
 export function ApiEventsProvider({
   children,
-  initialState = new ImmutableMap<string, ApiEvent>(testEvents),
+  initialState = new ImmutableMap<string, ApiEvent>(),
 }: ApiEventsProviderProps) {
   const [apiEvents, dispatchApiEvents] = useReducer(
     apiEventsReducer,

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -20,6 +20,7 @@ export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
     [
       "1",
       {
+        id: "1",
         isError: true,
         title: "string",
         status: 400,
@@ -29,6 +30,7 @@ export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
     [
       "2",
       {
+        id: "2",
         isError: true,
         title: "Event Two",
         status: 400,

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -16,8 +16,29 @@ const ApiEventsContext = createContext<ApiEventsContextValues | undefined>(
 );
 
 export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
+  const testEvents = [
+    [
+      "1",
+      {
+        isError: true,
+        title: "string",
+        status: 400,
+        statusText: "Bad Request",
+      },
+    ],
+    [
+      "2",
+      {
+        isError: true,
+        title: "Event Two",
+        status: 400,
+        statusText: "Bad Request",
+      },
+    ],
+  ] as const;
+
   const [apiEvents, setApiEvents] = useState<ApiEventsMap>(
-    () => new ImmutableMap<string, ApiEvent>()
+    () => new ImmutableMap<string, ApiEvent>(testEvents)
   );
 
   return (

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -12,6 +12,7 @@ import { ImmutableMap } from "map-immute";
 import { ApiEvent } from "./types";
 
 export type ApiEventsMap = ImmutableMap<string, ApiEvent>;
+export type InitialApiEventsState = Iterable<readonly [string, ApiEvent]>;
 
 export type ApiEventAction =
   | {
@@ -54,16 +55,28 @@ const ApiEventsContext = createContext<ApiEventsContextValues | undefined>(
 );
 
 export type ApiEventsProviderProps = {
-  initialState?: ApiEventsMap;
+  initialState?: InitialApiEventsState;
 } & PropsWithChildren<{}>;
 
+/**
+ *
+ * @param initialState - iterables to initialize the state
+ * @param children
+ * @returns
+ */
 export function ApiEventsProvider({
   children,
-  initialState = new ImmutableMap<string, ApiEvent>(),
+  initialState,
 }: ApiEventsProviderProps) {
+  const setupInitialState = (intialState?: InitialApiEventsState) => {
+    return intialState instanceof ImmutableMap<string, ApiEvent>
+      ? intialState
+      : new ImmutableMap<string, ApiEvent>(intialState);
+  };
+
   const [apiEvents, dispatchApiEvents] = useReducer(
     apiEventsReducer,
-    initialState
+    setupInitialState(initialState)
   );
 
   return (

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -62,6 +62,7 @@ const testEvents = [
       title: "string",
       status: 400,
       statusText: "Bad Request",
+      level: "error",
     },
   ],
   [
@@ -72,6 +73,7 @@ const testEvents = [
       title: "Event Two",
       status: 400,
       statusText: "Bad Request",
+      level: "error",
     },
   ],
 ] as const;

--- a/src/common/ApiResponse/ApiEventsContext.tsx
+++ b/src/common/ApiResponse/ApiEventsContext.tsx
@@ -1,50 +1,96 @@
 "use client";
 
-import { PropsWithChildren, createContext, useContext, useState } from "react";
+import {
+  Dispatch,
+  PropsWithChildren,
+  createContext,
+  useContext,
+  useReducer,
+} from "react";
 import { ImmutableMap } from "map-immute";
 
 import { ApiEvent } from "./types";
 
 export type ApiEventsMap = ImmutableMap<string, ApiEvent>;
+
+export type ApiEventAction =
+  | {
+      type: "set";
+      event: ApiEvent;
+    }
+  | {
+      type: "delete";
+      id: string;
+    }
+  | {
+      type: "clear";
+    };
+
+export function apiEventsReducer(
+  state: ApiEventsMap,
+  action: ApiEventAction
+): ApiEventsMap {
+  switch (action.type) {
+    case "set":
+      return state.set(action.event.id, action.event);
+    case "delete":
+      const result = state.safeDelete(action.id);
+      if (!result) return state;
+      return result;
+    case "clear":
+      return state.safeClear();
+    default:
+      return state;
+  }
+}
+
 export type ApiEventsContextValues = {
   apiEvents: ApiEventsMap;
-  setApiEvents: (apiEvents: ApiEventsMap) => void;
+  dispatchApiEvents: Dispatch<ApiEventAction>;
 };
 
 const ApiEventsContext = createContext<ApiEventsContextValues | undefined>(
   undefined
 );
 
-export function ApiEventsProvider({ children }: PropsWithChildren<{}>) {
-  const testEvents = [
-    [
-      "1",
-      {
-        id: "1",
-        isError: true,
-        title: "string",
-        status: 400,
-        statusText: "Bad Request",
-      },
-    ],
-    [
-      "2",
-      {
-        id: "2",
-        isError: true,
-        title: "Event Two",
-        status: 400,
-        statusText: "Bad Request",
-      },
-    ],
-  ] as const;
+const testEvents = [
+  [
+    "1",
+    {
+      id: "1",
+      isError: true,
+      title: "string",
+      status: 400,
+      statusText: "Bad Request",
+    },
+  ],
+  [
+    "2",
+    {
+      id: "2",
+      isError: true,
+      title: "Event Two",
+      status: 400,
+      statusText: "Bad Request",
+    },
+  ],
+] as const;
 
-  const [apiEvents, setApiEvents] = useState<ApiEventsMap>(
-    () => new ImmutableMap<string, ApiEvent>(testEvents)
+export type ApiEventsProviderProps = {
+  initialState?: ApiEventsMap;
+} & PropsWithChildren<{}>;
+
+export function ApiEventsProvider({
+  children,
+  initialState = new ImmutableMap<string, ApiEvent>(testEvents),
+}: ApiEventsProviderProps) {
+  const [apiEvents, dispatchApiEvents] = useReducer(
+    apiEventsReducer,
+    initialState
   );
 
   return (
-    <ApiEventsContext.Provider value={{ apiEvents, setApiEvents }}>
+    <ApiEventsContext.Provider value={{ apiEvents, dispatchApiEvents }}>
       {children}
     </ApiEventsContext.Provider>
   );

--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -24,3 +24,18 @@ export function createApiResponse(
     data: isError ? undefined : result.data,
   };
 }
+
+export type createDefaultApiErrorEventOptions = CreateApiResponseOptions;
+
+export function createDefaultApiErrorEvent(
+  options: createDefaultApiErrorEventOptions
+) {
+  return {
+    id: options?.id || uuid(),
+    isError: true,
+    title: options.message,
+    status: 500,
+    statusText: "Internal Server Error",
+    level: "error",
+  } as const;
+}

--- a/src/common/ApiResponse/createApiResponse.ts
+++ b/src/common/ApiResponse/createApiResponse.ts
@@ -1,18 +1,23 @@
+import { v4 as uuid } from "uuid";
 import { AxiosResponse } from "axios";
 
 import { ApiResponse } from "./types";
 import { isErrorStatusCode } from "./utils";
 
+export type CreateApiResponseOptions = { message: string; id?: string };
+
 export function createApiResponse(
   result: AxiosResponse,
-  successMessage: string
+  options: CreateApiResponseOptions
 ): ApiResponse<any> {
   const isError = isErrorStatusCode(result.status);
 
   return {
     apiEvent: {
+      id: options?.id || uuid(),
       isError,
-      title: isError ? result.data.message : successMessage,
+      level: "error",
+      title: options.message,
       status: result.status,
       statusText: result.statusText,
     },

--- a/src/common/ApiResponse/tests/ApiEventsProvider.test.tsx
+++ b/src/common/ApiResponse/tests/ApiEventsProvider.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * This file contains tests only to validate if the initial state prop is working.
+ *
+ * Otherwise, do not test this Provider directly. Instead, test this by proxy via the Components that use it.
+ *
+ * The user cannot see the ApiEventsProvider, which will make this an implementation detail.
+ */
+import { render } from "@testing-library/react";
+
+import { ApiEventsProvider, InitialApiEventsState } from "../ApiEventsContext";
+import { ImmutableMap } from "map-immute";
+import { ApiEvent } from "../types";
+
+function setupRender(initialState: InitialApiEventsState) {
+  return render(<ApiEventsProvider initialState={initialState} />);
+}
+
+it("throws an error when an invalid initalState is provided", () => {
+  const initialState: any = {};
+
+  expect(() => setupRender(initialState)).toThrow();
+});
+
+test("does not throw error when initialState is not provided", () => {
+  expect(setupRender).not.toThrow();
+});
+
+it("allows an ImmutableMap<string, ApiEvent> as the  initialState", () => {
+  const initialState = new ImmutableMap<string, ApiEvent>();
+
+  expect(() => setupRender(initialState)).not.toThrow();
+});
+
+it("allows a Map<string, ApiEvent> as the initialState", () => {
+  const initialState = new Map<string, ApiEvent>();
+
+  expect(() => setupRender(initialState)).not.toThrow();
+});
+
+it("allows an Array<[string, ApiEvent]> as the initialState", () => {
+  const initialState = new Array<[string, ApiEvent]>();
+
+  expect(() => setupRender(initialState)).not.toThrow();
+});

--- a/src/common/ApiResponse/tests/createApiResponse.test.ts
+++ b/src/common/ApiResponse/tests/createApiResponse.test.ts
@@ -5,7 +5,7 @@ import { ApiResponse } from "../types";
 type AxiosTableTestCases = {
   name: string;
   input: AxiosResponse;
-  successMessage: string;
+  message: string;
   expected: ApiResponse<any>;
 }[];
 
@@ -88,9 +88,11 @@ const axiosTestCases: AxiosTableTestCases = [
   {
     name: "handles 200 OK Axios Response",
     input: Axios200Response_GetOffersList,
-    successMessage: "Successfully loaded Offers list.",
+    message: "Successfully loaded Offers list.",
     expected: {
       apiEvent: {
+        id: "1",
+        level: "error",
         isError: false,
         title: "Successfully loaded Offers list.",
         status: 200,
@@ -122,9 +124,11 @@ const axiosTestCases: AxiosTableTestCases = [
   {
     name: "handles 201 Created Axios Response",
     input: Axios201Response_CreateOffer,
-    successMessage: "Successfully created Offer.",
+    message: "Successfully created Offer.",
     expected: {
       apiEvent: {
+        id: "1",
+        level: "error",
         isError: false,
         title: "Successfully created Offer.",
         status: 201,
@@ -153,9 +157,11 @@ const axiosTestCases: AxiosTableTestCases = [
   {
     name: "handles 401 Unauthorized Axios Error Response",
     input: Axios401Response,
-    successMessage: "Successfully loaded Offers.",
+    message: "Invalid Token: please log in again.",
     expected: {
       apiEvent: {
+        id: "1",
+        level: "error",
         isError: true,
         title: "Invalid Token: please log in again.",
         status: 401,
@@ -167,9 +173,11 @@ const axiosTestCases: AxiosTableTestCases = [
   {
     name: "handles 500 Internal Server Error Axios Response",
     input: Axios500Response,
-    successMessage: "Successfully loaded Task.",
+    message: "Invalid Task",
     expected: {
       apiEvent: {
+        id: "1",
+        level: "error",
         isError: true,
         title: "Invalid Task",
         status: 500,
@@ -180,8 +188,11 @@ const axiosTestCases: AxiosTableTestCases = [
   },
 ];
 
-it.each(axiosTestCases)("$name", ({ input, successMessage, expected }) => {
-  const actual = createApiResponse(input, successMessage);
+it.each(axiosTestCases)("$name", ({ input, message, expected }) => {
+  const actual = createApiResponse(input, {
+    message,
+    id: "1",
+  });
 
-  expect(actual).toEqual(expected);
+  expect(actual).toMatchObject(expected);
 });

--- a/src/common/ApiResponse/types.ts
+++ b/src/common/ApiResponse/types.ts
@@ -4,6 +4,7 @@ export type ApiEvent = {
   title: string;
   status: number;
   statusText: string;
+  level: "info" | "warn" | "error";
 };
 
 export type ApiResponse<TData> = {

--- a/src/common/ApiResponse/types.ts
+++ b/src/common/ApiResponse/types.ts
@@ -1,4 +1,5 @@
 export type ApiEvent = {
+  id: string;
   isError: boolean;
   title: string;
   status: number;

--- a/src/components/PageWithNotifications.tsx
+++ b/src/components/PageWithNotifications.tsx
@@ -11,14 +11,14 @@ export function PageWithNotifications({
   ...otherProps
 }: PageWithNotificationsProps) {
   const { apiEvents } = useApiEvents();
-  const events = [...apiEvents.entries()];
+  const events = [...apiEvents.values()];
 
   return (
     <Page {...otherProps}>
       <Layout>
-        {events.map(([eventId, event]) => (
+        {events.map((event) => (
           <BaseNotification
-            key={eventId}
+            key={event.id}
             title={event.title}
             status="critical"
           />

--- a/src/components/PageWithNotifications.tsx
+++ b/src/components/PageWithNotifications.tsx
@@ -4,15 +4,10 @@ import { ComponentPropsWithoutRef } from "react";
 import { useApiEvents } from "src/common/ApiResponse/ApiEventsContext";
 import { BaseNotification } from "./Notification";
 
-export type PageWithNotificationsProps = ComponentPropsWithoutRef<
-  typeof Page
-> & {
-  notification?: () => React.ReactNode;
-};
+export type PageWithNotificationsProps = ComponentPropsWithoutRef<typeof Page>;
 
 export function PageWithNotifications({
   children,
-  notification,
   ...otherProps
 }: PageWithNotificationsProps) {
   const { apiEvents } = useApiEvents();
@@ -28,8 +23,6 @@ export function PageWithNotifications({
             status="critical"
           />
         ))}
-
-        {notification ? notification() : null}
         {children}
       </Layout>
     </Page>

--- a/src/components/PageWithNotifications.tsx
+++ b/src/components/PageWithNotifications.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Page, Layout } from "@shopify/polaris";
 import { ComponentPropsWithoutRef } from "react";
 import { useApiEvents } from "src/common/ApiResponse/ApiEventsContext";
@@ -6,11 +5,17 @@ import { BaseNotification } from "./Notification";
 
 export type PageWithNotificationsProps = ComponentPropsWithoutRef<typeof Page>;
 
+const EventLevelToNotificationStatus = {
+  info: "info",
+  warn: "warning",
+  error: "critical",
+} as const;
+
 export function PageWithNotifications({
   children,
   ...otherProps
 }: PageWithNotificationsProps) {
-  const { apiEvents } = useApiEvents();
+  const { apiEvents, dispatchApiEvents } = useApiEvents();
   const events = [...apiEvents.values()];
 
   return (
@@ -20,7 +25,13 @@ export function PageWithNotifications({
           <BaseNotification
             key={event.id}
             title={event.title}
-            status="critical"
+            status={EventLevelToNotificationStatus[event.level]}
+            onDismiss={() => {
+              dispatchApiEvents({
+                type: "delete",
+                id: event.id,
+              });
+            }}
           />
         ))}
         {children}

--- a/src/components/PageWithNotifications.tsx
+++ b/src/components/PageWithNotifications.tsx
@@ -1,5 +1,8 @@
+import React from "react";
 import { Page, Layout } from "@shopify/polaris";
 import { ComponentPropsWithoutRef } from "react";
+import { useApiEvents } from "src/common/ApiResponse/ApiEventsContext";
+import { BaseNotification } from "./Notification";
 
 export type PageWithNotificationsProps = ComponentPropsWithoutRef<
   typeof Page
@@ -12,9 +15,20 @@ export function PageWithNotifications({
   notification,
   ...otherProps
 }: PageWithNotificationsProps) {
+  const { apiEvents } = useApiEvents();
+  const events = [...apiEvents.entries()];
+
   return (
     <Page {...otherProps}>
       <Layout>
+        {events.map(([eventId, event]) => (
+          <BaseNotification
+            key={eventId}
+            title={event.title}
+            status="critical"
+          />
+        ))}
+
         {notification ? notification() : null}
         {children}
       </Layout>

--- a/src/components/tests/PageWithNotifications.test.tsx
+++ b/src/components/tests/PageWithNotifications.test.tsx
@@ -1,15 +1,27 @@
-import { render, screen } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 
 import { renderWithPolarisTestProvider } from "src/test/utils";
 import {
   PageWithNotifications,
   PageWithNotificationsProps,
 } from "../PageWithNotifications";
-import { ApiEventsProvider } from "src/common/ApiResponse/ApiEventsContext";
+import {
+  ApiEventsProvider,
+  InitialApiEventsState,
+} from "src/common/ApiResponse/ApiEventsContext";
+import userEvent from "@testing-library/user-event";
 
-function setupRender(componentProps?: PageWithNotificationsProps) {
+type SetupRenderProps = {
+  componentProps?: PageWithNotificationsProps;
+  initialProviderState?: InitialApiEventsState;
+};
+
+function setupRender({
+  componentProps,
+  initialProviderState,
+}: SetupRenderProps = {}) {
   return renderWithPolarisTestProvider(
-    <ApiEventsProvider>
+    <ApiEventsProvider initialState={initialProviderState}>
       <PageWithNotifications {...componentProps} />
     </ApiEventsProvider>
   );
@@ -18,4 +30,67 @@ function setupRender(componentProps?: PageWithNotificationsProps) {
 test("Smoke test if BaseNotification renders", () => {
   const { baseElement } = setupRender();
   expect(baseElement).toBeInTheDocument();
+});
+
+it("does not display a notification when there are no API Events", () => {
+  setupRender();
+
+  const notification = screen.queryByText(/^test notification$/i);
+
+  expect(notification).toBeFalsy();
+});
+
+it("displays a notification when there is an API Event", () => {
+  const intialApiEventsState: InitialApiEventsState = [
+    [
+      "1",
+      {
+        id: "1",
+        isError: true,
+        title: "Test Notification",
+        status: 400,
+        statusText: "Bad Request",
+        level: "error",
+      },
+    ],
+  ] as const;
+
+  setupRender({ initialProviderState: intialApiEventsState });
+
+  const notification = screen.getByText(/^test notification$/i);
+
+  expect(notification).toBeTruthy();
+});
+
+it("notification disappears when closed", async () => {
+  const intialApiEventsState: InitialApiEventsState = [
+    [
+      "1",
+      {
+        id: "1",
+        isError: true,
+        title: "Test Notification",
+        status: 400,
+        statusText: "Bad Request",
+        level: "error",
+      },
+    ],
+  ] as const;
+
+  const user = userEvent.setup();
+  setupRender({ initialProviderState: intialApiEventsState });
+
+  let notification = screen.queryByText(/^test notification$/i);
+
+  expect(notification).toBeTruthy();
+
+  const dismissNotificationButton = screen.getByLabelText(
+    /^dismiss notification$/i
+  );
+
+  await user.click(dismissNotificationButton);
+
+  notification = screen.queryByText(/^test notification$/i);
+
+  expect(notification).toBeFalsy();
 });

--- a/src/components/tests/PageWithNotifications.test.tsx
+++ b/src/components/tests/PageWithNotifications.test.tsx
@@ -6,10 +6,13 @@ import {
   PageWithNotifications,
   PageWithNotificationsProps,
 } from "../PageWithNotifications";
+import { ApiEventsProvider } from "src/common/ApiResponse/ApiEventsContext";
 
 function setupRender(componentProps?: PageWithNotificationsProps) {
   return renderWithPolarisTestProvider(
-    <PageWithNotifications {...componentProps} />
+    <ApiEventsProvider>
+      <PageWithNotifications {...componentProps} />
+    </ApiEventsProvider>
   );
 }
 

--- a/src/components/tests/PageWithNotifications.test.tsx
+++ b/src/components/tests/PageWithNotifications.test.tsx
@@ -1,6 +1,5 @@
-import { screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 
-import { BaseNotification } from "../Notification";
 import { renderWithPolarisTestProvider } from "src/test/utils";
 import {
   PageWithNotifications,
@@ -19,14 +18,4 @@ function setupRender(componentProps?: PageWithNotificationsProps) {
 test("Smoke test if BaseNotification renders", () => {
   const { baseElement } = setupRender();
   expect(baseElement).toBeInTheDocument();
-});
-
-it("displays a notification if one is passed in", () => {
-  setupRender({
-    notification: () => <BaseNotification title="You done messed up" />,
-  });
-
-  const notificationHeading = screen.getByText("You done messed up");
-
-  expect(notificationHeading).toBeTruthy();
 });

--- a/src/domains/billing/Checkout/hooks/useTaskFetch.tsx
+++ b/src/domains/billing/Checkout/hooks/useTaskFetch.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import fetch from "node-fetch";
 
-export const getTaskURL = `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks/`;
+export const getTaskURL = `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`;
 
 export const useTaskFetch = (taskId: string) => {
   return useQuery({

--- a/src/domains/tasks/ViewOffers/api/index.tsx
+++ b/src/domains/tasks/ViewOffers/api/index.tsx
@@ -1,6 +1,9 @@
 import { Task, Offer } from "@Tasks/common/types";
 import axios from "axios";
 
+export const getOffersUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`;
+export const getTasksUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`;
+
 export async function completeOfferMutation(taskId: string) {
   axios
     .patch(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks/${taskId}/completed`)
@@ -17,12 +20,9 @@ export async function getTaskQuery(taskId: string) {
 }
 
 export async function getOffersOfProviderQuery() {
-  const response = await axios.get(
-    `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`,
-    {
-      params: { my_offers: true },
-    }
-  );
+  const response = await axios.get(getOffersUrl, {
+    params: { my_offers: true },
+  });
 
   return response.data.data.offers as Array<Offer>;
 }

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -170,8 +170,6 @@ export function ViewOffersPage({ status }: ViewOffersPageProps) {
             event: apiEvent,
           });
         }
-
-        console.log(error);
       });
   }, [dispatchApiEvents, status]);
 

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -173,7 +173,7 @@ export function ViewOffersPage({
 
         console.log(error);
       });
-  }, [status]);
+  }, [dispatchApiEvents, status]);
 
   return (
     <StyledDiv aria-label="View Offers Page">

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -102,8 +102,6 @@ function EmptyTaskCardBody({ loading }: { loading: boolean }) {
 
 const StyledDiv = styled.div`
   .Polaris-Layout {
-    flex-direction: column-reverse;
-
     .Polaris-Layout__Section {
       width: 100%;
     }

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -112,11 +112,11 @@ const StyledDiv = styled.div`
   }
 `;
 
-export function ViewOffersPage({
-  status,
-}: {
+export type ViewOffersPageProps = {
   status: "authenticated" | "loading" | "unauthenticated";
-}) {
+};
+
+export function ViewOffersPage({ status }: ViewOffersPageProps) {
   const { dispatchApiEvents } = useApiEvents();
 
   const [offers, setOffers] = useState(new Array<Offer>());

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -147,13 +147,7 @@ export function ViewOffersPage({
 
   return (
     <StyledDiv aria-label="View Offers Page">
-      <PageWithNotifications
-        title="Offers"
-        notification={() => (
-          <BaseNotification title="You done messed up" status="critical" />
-        )}
-        fullWidth
-      >
+      <PageWithNotifications title="Offers" fullWidth>
         <Layout.Section oneHalf>
           {offers.map((offer) => {
             return (

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -23,7 +23,10 @@ import {
 } from "../api";
 import { PageWithNotifications } from "src/components";
 import { useApiEvents } from "src/common/ApiResponse/ApiEventsContext";
-import { createApiResponse } from "src/common/ApiResponse";
+import {
+  createApiResponse,
+  createDefaultApiErrorEvent,
+} from "src/common/ApiResponse";
 import { AxiosError } from "axios";
 
 const TaskCard = dynamic(() =>
@@ -152,6 +155,24 @@ export function ViewOffersPage({
         setOffers(offers);
       })
       .catch((error) => {
+        if (error instanceof AxiosError) {
+          const errorMessage =
+            "Failed to load offers. Please contact support if refreshing the page does not work.";
+
+          const apiEvent = error.response
+            ? createApiResponse(error.response, {
+                message: errorMessage,
+              }).apiEvent
+            : createDefaultApiErrorEvent({
+                message: errorMessage,
+              });
+
+          dispatchApiEvents({
+            type: "set",
+            event: apiEvent,
+          });
+        }
+
         console.log(error);
       });
   }, [status]);

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -1,9 +1,14 @@
 import { screen } from "@testing-library/react";
 import { ViewOffersPage } from "../ViewOffersPage";
 import { renderWithPolarisTestProvider } from "src/test/utils";
+import { ApiEventsProvider } from "src/common/ApiResponse/ApiEventsContext";
 
 test("smoke test if it renders", () => {
-  renderWithPolarisTestProvider(<ViewOffersPage status="authenticated" />);
+  renderWithPolarisTestProvider(
+    <ApiEventsProvider>
+      <ViewOffersPage status="authenticated" />
+    </ApiEventsProvider>
+  );
 
   const viewOffersPage = screen.getByLabelText(/^view offers page$/i);
   expect(viewOffersPage).toBeTruthy();

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -1,4 +1,7 @@
-import { screen } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
+import { rest } from "msw";
+import { server } from "src/mocks/server";
+
 import { ViewOffersPage, ViewOffersPageProps } from "../ViewOffersPage";
 import { renderWithPolarisTestProvider } from "src/test/utils";
 import {
@@ -6,24 +9,117 @@ import {
   InitialApiEventsState,
 } from "src/common/ApiResponse/ApiEventsContext";
 
+import { getOffersUrl } from "@Tasks/ViewOffers/api";
+import userEvent from "@testing-library/user-event";
+import { getTaskURL } from "@Billing/Checkout/hooks";
+
 type setupRenderOptions = {
   componentProps?: ViewOffersPageProps;
   initialProviderState?: InitialApiEventsState;
 };
 
-function setupRender(options: setupRenderOptions = {}) {
+async function setupRender({
+  initialProviderState,
+  componentProps,
+}: setupRenderOptions = {}) {
   return renderWithPolarisTestProvider(
-    <ApiEventsProvider>
-      <ViewOffersPage status="authenticated" />
+    <ApiEventsProvider initialState={initialProviderState}>
+      <ViewOffersPage
+        status={
+          componentProps?.status ? componentProps.status : "unauthenticated"
+        }
+      />
     </ApiEventsProvider>
   );
 }
 
-test("smoke test if it renders", () => {
+test("smoke test if it renders", async () => {
   const componentProps = { status: "authenticated" } as const;
 
-  setupRender({ componentProps });
+  await act(() => {
+    setupRender({ componentProps });
+  });
 
   const viewOffersPage = screen.getByLabelText(/^view offers page$/i);
   expect(viewOffersPage).toBeTruthy();
+});
+
+test("loads a list of OfferItems", async () => {
+  const componentProps = { status: "authenticated" } as const;
+
+  await act(() => {
+    setupRender({ componentProps });
+  });
+
+  const offerItems = screen.getAllByRole("heading", { name: /^offer$/i });
+  expect(offerItems.length).toBeGreaterThan(1);
+});
+
+test("displays error notification when getOffersOfProviderQuery fails", async () => {
+  const testErrorMessage = "THIS IS A TEST FAILURE";
+  server.use(
+    rest.get(getOffersUrl, async (req, res, ctx) => {
+      return res(ctx.status(500), ctx.json({ message: testErrorMessage }));
+    })
+  );
+
+  await act(() => {
+    setupRender();
+  });
+
+  const notification = screen.getByText(/^Failed to load offers./i);
+  expect(notification).toBeTruthy();
+});
+
+test("displays error notification when getTaskQuery fails", async () => {
+  server.use(
+    rest.get(getOffersUrl, async (req, res, ctx) => {
+      const serverResponse = {
+        status: "success",
+        results: 16,
+        data: {
+          offers: [
+            {
+              status: "completed",
+              _id: "6360610f5fac2e5082d00912",
+              offerAmt: 195,
+              comments: "waerawerawerw123123123123123",
+              providerId: "acct_1Lur4rIWxYvLVjGY",
+              task: "636060fa5fac2e5082d00903",
+              createdAt: "2022-10-31T23:58:07.185Z",
+              updatedAt: "2022-11-06T09:28:04.710Z",
+              __v: 0,
+              timeElapsed: "121 days ago",
+              id: "6360610f5fac2e5082d00912",
+            },
+          ],
+        },
+      };
+
+      return res(ctx.status(200), ctx.json(serverResponse));
+    }),
+    rest.get(`${getTaskURL}/:id`, async (req, res, ctx) => {
+      return res(
+        ctx.status(404),
+        ctx.json({ status: "error", message: "Invalid task" })
+      );
+    })
+  );
+
+  const user = userEvent.setup();
+
+  await act(() => {
+    setupRender();
+  });
+
+  const viewTaskDetailsButton = screen.getByRole("button", {
+    name: /^view task details$/i,
+  });
+
+  await act(async () => {
+    await user.click(viewTaskDetailsButton);
+  });
+
+  const notification = screen.getByText(/^invalid task$/i);
+  expect(notification).toBeTruthy();
 });

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -1,14 +1,28 @@
 import { screen } from "@testing-library/react";
-import { ViewOffersPage } from "../ViewOffersPage";
+import { ViewOffersPage, ViewOffersPageProps } from "../ViewOffersPage";
 import { renderWithPolarisTestProvider } from "src/test/utils";
-import { ApiEventsProvider } from "src/common/ApiResponse/ApiEventsContext";
+import {
+  ApiEventsProvider,
+  InitialApiEventsState,
+} from "src/common/ApiResponse/ApiEventsContext";
 
-test("smoke test if it renders", () => {
-  renderWithPolarisTestProvider(
+type setupRenderOptions = {
+  componentProps?: ViewOffersPageProps;
+  initialProviderState?: InitialApiEventsState;
+};
+
+function setupRender(options: setupRenderOptions = {}) {
+  return renderWithPolarisTestProvider(
     <ApiEventsProvider>
       <ViewOffersPage status="authenticated" />
     </ApiEventsProvider>
   );
+}
+
+test("smoke test if it renders", () => {
+  const componentProps = { status: "authenticated" } as const;
+
+  setupRender({ componentProps });
 
   const viewOffersPage = screen.getByLabelText(/^view offers page$/i);
   expect(viewOffersPage).toBeTruthy();

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -33,6 +33,45 @@ async function setupRender({
   );
 }
 
+const getOffersSuccessHandler = rest.get(
+  getOffersUrl,
+  async (req, res, ctx) => {
+    const serverResponse = {
+      status: "success",
+      results: 16,
+      data: {
+        offers: [
+          {
+            status: "completed",
+            _id: "6360610f5fac2e5082d00912",
+            offerAmt: 195,
+            comments: "waerawerawerw123123123123123",
+            providerId: "acct_1Lur4rIWxYvLVjGY",
+            task: "636060fa5fac2e5082d00903",
+            createdAt: "2022-10-31T23:58:07.185Z",
+            updatedAt: "2022-11-06T09:28:04.710Z",
+            __v: 0,
+            timeElapsed: "121 days ago",
+            id: "6360610f5fac2e5082d00912",
+          },
+        ],
+      },
+    };
+
+    return res(ctx.status(200), ctx.json(serverResponse));
+  }
+);
+
+const getTaskNotFoundHandler = rest.get(
+  `${getTaskURL}/:id`,
+  async (req, res, ctx) => {
+    return res(
+      ctx.status(404),
+      ctx.json({ status: "error", message: "Task Not Found" })
+    );
+  }
+);
+
 test("smoke test if it renders", async () => {
   const componentProps = { status: "authenticated" } as const;
 
@@ -72,40 +111,8 @@ test("displays error notification when getOffersOfProviderQuery fails", async ()
 });
 
 test("displays error notification when getTaskQuery fails", async () => {
-  server.use(
-    rest.get(getOffersUrl, async (req, res, ctx) => {
-      const serverResponse = {
-        status: "success",
-        results: 16,
-        data: {
-          offers: [
-            {
-              status: "completed",
-              _id: "6360610f5fac2e5082d00912",
-              offerAmt: 195,
-              comments: "waerawerawerw123123123123123",
-              providerId: "acct_1Lur4rIWxYvLVjGY",
-              task: "636060fa5fac2e5082d00903",
-              createdAt: "2022-10-31T23:58:07.185Z",
-              updatedAt: "2022-11-06T09:28:04.710Z",
-              __v: 0,
-              timeElapsed: "121 days ago",
-              id: "6360610f5fac2e5082d00912",
-            },
-          ],
-        },
-      };
-
-      return res(ctx.status(200), ctx.json(serverResponse));
-    }),
-    rest.get(`${getTaskURL}/:id`, async (req, res, ctx) => {
-      return res(
-        ctx.status(404),
-        ctx.json({ status: "error", message: "Invalid task" })
-      );
-    })
-  );
-
+  // overrides the default MSW handlers
+  server.use(getOffersSuccessHandler, getTaskNotFoundHandler);
   const user = userEvent.setup();
 
   await act(() => {
@@ -120,6 +127,6 @@ test("displays error notification when getTaskQuery fails", async () => {
     await user.click(viewTaskDetailsButton);
   });
 
-  const notification = screen.getByText(/^invalid task$/i);
-  expect(notification).toBeTruthy();
+  const notification = screen.getByText(/^task not found$/i);
+  expect(notification).toBeInTheDocument();
 });

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
+import { getOffers } from "./handlers/offers.handler";
 import { getTask } from "./handlers/tasks.handler";
 
-export const handlers = [getTask];
+export const handlers = [getTask, getOffers];

--- a/src/mocks/handlers/offers.handler.ts
+++ b/src/mocks/handlers/offers.handler.ts
@@ -1,0 +1,41 @@
+import { rest } from "msw";
+import { getOffersUrl } from "@Tasks/ViewOffers/api";
+
+export const getOffers = rest.get(getOffersUrl, async (req, res, ctx) => {
+  const serverResponse = {
+    status: "success",
+    results: 16,
+    data: {
+      offers: [
+        {
+          status: "completed",
+          _id: "1",
+          offerAmt: 195,
+          comments: "waerawerawerw123123123123123",
+          providerId: "acct_1Lur4rIWxYvLVjGY",
+          task: "Task1",
+          createdAt: "2022-10-31T23:58:07.185Z",
+          updatedAt: "2022-11-06T09:28:04.710Z",
+          __v: 0,
+          timeElapsed: "121 days ago",
+          id: "1",
+        },
+        {
+          status: "completed",
+          _id: "2",
+          offerAmt: 195,
+          comments: "waerawerawerw123123123123123",
+          providerId: "acct_1Lur4rIWxYvLVjGY",
+          task: "Task2",
+          createdAt: "2022-10-31T23:58:07.185Z",
+          updatedAt: "2022-11-06T09:28:04.710Z",
+          __v: 0,
+          timeElapsed: "121 days ago",
+          id: "2",
+        },
+      ],
+    },
+  };
+
+  return res(ctx.status(200), ctx.json(serverResponse));
+});

--- a/src/mocks/handlers/tasks.handler.ts
+++ b/src/mocks/handlers/tasks.handler.ts
@@ -2,29 +2,65 @@ import { rest } from "msw";
 import { getTaskURL } from "@Billing/Checkout/hooks";
 
 const getTaskResponse = {
-  location: {
-    type: "Point",
-    name: "2000",
-    coordinates: "[0, 0]",
+  status: "success",
+  data: {
+    task: {
+      location: { type: "Point", name: "2000", coordinates: [0, 0] },
+      status: "open",
+      photos: [""],
+      _id: "6350d8e080c58772355d7645",
+      category: "Cleaning",
+      title: "Placeholder",
+      details: "asdfasdfasdfTest for provider",
+      dueDate: "2023-01-06T00:00:00.000Z",
+      budget: 200,
+      timeEstimate: "1-3hrs",
+      timeOfArrival: "7am-10am",
+      customerId: "cus_Me9Lz7memmLIEB",
+      createdAt: "2022-10-20T05:13:04.572Z",
+      updatedAt: "2022-10-20T05:13:04.572Z",
+      __v: 0,
+      timeElapsed: "133 days ago",
+      id: "6350d8e080c58772355d7645",
+      offers: [
+        {
+          firstName: "qwe",
+          photo:
+            "https://res.cloudinary.com/dxd5elnem/image/upload/c_thumb,w_200,g_face/v1633225891/users/blank-profile.png",
+          status: "completed",
+          _id: "63677e0114fc3b6d490feebb",
+          offerAmt: 2000,
+          comments: "123123123123123123123123123123",
+          providerId: "acct_1Lur4rIWxYvLVjGY",
+          task: "6350d8e080c58772355d7645",
+          createdAt: "2022-11-06T09:27:29.283Z",
+          updatedAt: "2023-01-17T09:44:36.085Z",
+          __v: 0,
+          timeElapsed: "116 days ago",
+          id: "63677e0114fc3b6d490feebb",
+        },
+        {
+          firstName: "qwe",
+          photo:
+            "https://res.cloudinary.com/dxd5elnem/image/upload/c_thumb,w_200,g_face/v1633225891/users/blank-profile.png",
+          status: "outbidded",
+          _id: "6368eaf5b3fe7465889dff57",
+          offerAmt: 123123,
+          comments: "123123123123123123123123123123",
+          providerId: "acct_1Lur4rIWxYvLVjGY",
+          task: "6350d8e080c58772355d7645",
+          createdAt: "2022-11-07T11:24:37.742Z",
+          updatedAt: "2023-01-17T09:40:16.351Z",
+          __v: 0,
+          timeElapsed: "115 days ago",
+          id: "6368eaf5b3fe7465889dff57",
+        },
+      ],
+      numOfOffers: 2,
+    },
   },
-  status: "open",
-  photos: [""],
-  _id: "6350d7bc80c58772355d7620",
-  category: "Cleaning",
-  title: "Placeholder",
-  details: "Test: End of Lease Cleaning",
-  dueDate: "2023-01-01T00:00:00.000Z",
-  budget: 200,
-  timeEstimate: "1-3hrs",
-  timeOfArrival: "7am-10am",
-  customerId: "cus_Me9GBxVg1aUC69",
-  createdAt: "2022-10-20T05:08:12.717Z",
-  updatedAt: "2022-10-20T05:08:12.717Z",
-  __v: 0,
-  timeElapsed: "8 days ago",
-  id: "6350d7bc80c58772355d7620",
 };
 
 export const getTask = rest.get(getTaskURL + ":id", (req, res, ctx) => {
-  return res(ctx.json(getTaskResponse));
+  return res(ctx.status(200), ctx.json(getTaskResponse));
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
This pull request adds functionality to handle the state management of API events. 

The following changes were made:

- added a new `apiEventsReducer` for the `apiEventsContext` to manage API request events and store their status
- added implementation in `ViewOffersPage` to handle failed Axios requests and update the relevant `apiEvent` status in the `apiEventsContext`

The `apiEventsReducer` provides centralized management of API request events, allowing the Application to display notifications to the user. 

The ViewOffersPage component now handles failed Axios requests by updating the apiEvents state. This establishes a proof of concept pattern which can be used throughout the entire application.

## Video Summary

https://www.loom.com/share/877f51d1eade4cdf884bf7da9314e01b

## Screenshots

[View Offers Page with Notification](https://user-images.githubusercontent.com/8443215/222671059-9fc2bf7b-4473-408d-861b-4cacb3e9e770.png)
[View Offers Page with Notification 2](https://user-images.githubusercontent.com/8443215/222671070-8c799e47-11eb-4363-8150-d662d0acf6ca.png)


## TODO
- [x] Testing
- [x] Screenshots
- [x] Self PR Review