### PR TITLE
feat: Display Different Menus to Different User Types

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,26 +1,40 @@
 import { Navigation as NavigationPrimitive } from "@shopify/polaris";
 import { FinancesMajor, HomeMajor, JobsMajor } from "@shopify/polaris-icons";
+import { useSession } from "next-auth/react";
 import { useRouter } from "next/router";
+import { Session } from "next-auth";
+
+function getMenuItems(session: Session | null) {
+  if (session?.user.customerId) {
+    return [
+      {
+        url: "/tasks",
+        label: "Tasks",
+        icon: JobsMajor,
+      },
+    ];
+  }
+
+  if (session?.user.providerId) {
+    return [
+      {
+        url: "/offers",
+        label: "Offers",
+        icon: FinancesMajor,
+      },
+    ];
+  }
+
+  return [];
+}
 
 export const Navigation = () => {
   const router = useRouter();
+  const { data: session } = useSession();
 
   return (
     <NavigationPrimitive location={router.asPath}>
-      <NavigationPrimitive.Section
-        items={[
-          {
-            url: "/tasks",
-            label: "Tasks",
-            icon: JobsMajor,
-          },
-          {
-            url: "/offers",
-            label: "Offers",
-            icon: FinancesMajor,
-          },
-        ]}
-      />
+      <NavigationPrimitive.Section items={getMenuItems(session)} />
     </NavigationPrimitive>
   );
 };

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,6 +1,7 @@
 import { TopBar as TopBarPrimitive, Text } from "@shopify/polaris";
 import { useSession } from "next-auth/react";
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
+import { Session } from "next-auth";
 
 import { routerPush } from "@Utils/index";
 import { useSetAuthHeader } from "@Users/common/hooks";
@@ -37,6 +38,24 @@ const secondaryMenuMarkup = (
   />
 );
 
+function getMenuItems(session?: Session) {
+  if (session?.user.customerId) {
+    return [
+      { content: "Listings", onAction: () => routerPush("/") },
+      { content: "Tasks", onAction: () => routerPush("/tasks") },
+    ];
+  }
+
+  if (session?.user.providerId) {
+    return [
+      { content: "Listings", onAction: () => routerPush("/") },
+      { content: "Offers", onAction: () => routerPush("/offers") },
+    ];
+  }
+
+  return [{ content: "Listings", onAction: () => routerPush("/") }];
+}
+
 /**
  * Top Navigation Bar
  */
@@ -62,9 +81,7 @@ export const TopBar = () => {
     <TopBarPrimitive.UserMenu
       actions={[
         {
-          items: [
-            { content: "Account", onAction: () => routerPush("/account") },
-          ],
+          items: getMenuItems(session),
         },
         {
           items: [{ content: "Sign Out", onAction: signOut }],


### PR DESCRIPTION
This pull request adds navigation so that mobile users can navigate between different pages.

And unifies the Desktop menus with the newly added Mobile menus.

### Provider Screenshots
[Provider View Desktop](https://user-images.githubusercontent.com/8443215/224527728-6fb32b24-5998-4b48-9b18-7f408bcc5ba9.png)
[Provider View Mobile](https://user-images.githubusercontent.com/8443215/224527786-32a006cb-1bf3-4f00-b5d0-d426d65d0709.png)

### Customer Screenshots
[Customer View Desktop](https://user-images.githubusercontent.com/8443215/224527729-ac0b1f0f-d300-4412-9331-91ffbe091bea.png)
[Customer View Mobile](https://user-images.githubusercontent.com/8443215/224527732-fe0f265a-6962-4800-a36c-c156b8f52671.png)
