### PR TITLE
fix: providers signup not updating correct details to user documents

### DIFF
--- a/src/domains/users/ProviderSignUp/hooks/useProviderSignUpForm.tsx
+++ b/src/domains/users/ProviderSignUp/hooks/useProviderSignUpForm.tsx
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import axios from "axios";
-import { createUser } from "@Users/common/api";
+import { createUser, signIn } from "@Users/common/api";
 
 export const formSchema = z
   .object({
@@ -36,6 +36,9 @@ const fetchProviderOnboardingUrl = async (userId: string) => {
 
 export const submitHandler = async (data: SignUpFormState) => {
   const userId = await createUser(data);
+
+  await signIn({ email: data.email, password: data.password });
+
   const providerOnboardingUrl = await fetchProviderOnboardingUrl(userId);
   window.location.assign(providerOnboardingUrl);
 };

--- a/src/domains/users/common/api/index.tsx
+++ b/src/domains/users/common/api/index.tsx
@@ -13,7 +13,7 @@ import { LoginFormState } from "@Users/Login/LoginPage";
 import { SignUpFormState } from "@Users/CustomerSignUp/hooks";
 
 export const signIn = async (formValues: LoginFormState) => {
-  const signInResponse = nextAuthSignIn("credentials", {
+  const signInResponse = await nextAuthSignIn("credentials", {
     ...formValues,
     redirect: false,
     callbackUrl: "/",
@@ -29,17 +29,10 @@ export const signIn = async (formValues: LoginFormState) => {
  * Original signup endpoint for all users
  */
 export const createUser = async (user: SignUpFormState) => {
-  const credentials = {
-    email: user.email,
-    password: user.password,
-  };
-
   const signUpResponse = await axios.post(
     `${process.env.NEXT_PUBLIC_API_URL}api/v1/users/signUp`,
     user
   );
-
-  await signIn(credentials);
 
   return signUpResponse.data.data.user._id;
 };


### PR DESCRIPTION
This issue was caused by a race condition in the signIn function, which would return before fully resolving. Which resulted in an old JWT token being sent to the backend instead of a new token.

For context:
- User signs up as Provider
- We create a Migram User: `POST /users`
- The we request for a redirect link to the Stripe Connect Onboarding link. <-- this is where the old JWT was sent
- Backend creates new Stripe Account and updates user based on the JWT user.