### PR TITLE
feat: add Toast notifications

### DIFF
--- a/src/common/features/notifications/components/PageWithNotifications.tsx
+++ b/src/common/features/notifications/components/PageWithNotifications.tsx
@@ -1,4 +1,4 @@
-import { Page, Layout } from "@shopify/polaris";
+import { Page, Layout, Toast } from "@shopify/polaris";
 import { ComponentPropsWithoutRef } from "react";
 import { useNotifications } from "src/common/features/notifications";
 import { BaseNotification } from "./Notification";
@@ -15,20 +15,38 @@ export function PageWithNotifications({
   return (
     <Page {...otherProps}>
       <Layout>
-        {events.map((event) => (
-          <BaseNotification
-            key={event.id}
-            title={event.title}
-            status={event.status}
-            onDismiss={() => {
-              dispatchApiEvents({
-                type: "delete",
-                id: event.id,
-              });
-            }}
-          />
-        ))}
+        {events
+          .filter((i) => i.type === "notification")
+          .map((event) => (
+            <BaseNotification
+              key={event.id}
+              title={event.title}
+              status={event.status}
+              onDismiss={() => {
+                dispatchApiEvents({
+                  type: "delete",
+                  id: event.id,
+                });
+              }}
+            />
+          ))}
         {children}
+
+        {events
+          .filter((i) => i.type === "toast")
+          .map((event) => (
+            <Toast
+              key={event.id}
+              content={event.title}
+              error={event.isError}
+              onDismiss={() => {
+                dispatchApiEvents({
+                  type: "delete",
+                  id: event.id,
+                });
+              }}
+            />
+          ))}
       </Layout>
     </Page>
   );


### PR DESCRIPTION
This pull request adds implementation to render a Toast components based on the Notifications API.

## Screenshots

[Mobile Screenshot](https://user-images.githubusercontent.com/8443215/225839014-ab67957e-777e-4b08-b490-61662739d4eb.png)

## Testing

To test the feature, you will have to navigate to the  ClientProviders file and add the following inititalState prop. This will cause the application to render an Error Toast component.

```tsx
// src/components/ClientProviders.tsx
initialState={[
  [
    "key",
    {
      id: "key",
      isError: true,
      title: "Something went wrong.",
      type: "toast",
      status: "critical",
      source: "test",
    } as const,
  ],
]}
```

