### PR TITLE
fix: form styling

### DIFF
--- a/src/components/FormPaddingDiv.tsx
+++ b/src/components/FormPaddingDiv.tsx
@@ -1,0 +1,13 @@
+import styled from "styled-components";
+
+/**
+ * Adds some padding on mobile viewports,
+ * Otherwise the forms will go up to the edges of the screen.
+ */
+export const FormPaddingDiv = styled.div`
+  padding: 1rem;
+
+  @media (min-width: 768px) {
+    padding: 0;
+  }
+`;

--- a/src/domains/tasks/CreateTask/components/CreateTaskPage.tsx
+++ b/src/domains/tasks/CreateTask/components/CreateTaskPage.tsx
@@ -1,4 +1,4 @@
-import { Form, FormLayout, Button, Text } from "@shopify/polaris";
+import { Form, FormLayout, Button, Text, Layout } from "@shopify/polaris";
 
 import { TextField, Select } from "src/components/index";
 
@@ -10,9 +10,8 @@ import {
   TaskTimeEstimateSchema,
   TaskTimeOfArrivalSchema,
 } from "@Tasks/common/types";
-import {
-  PageWithNotifications,
-} from "src/common/features/notifications";
+import { PageWithNotifications } from "src/common/features/notifications";
+import { FormPaddingDiv } from "src/components/FormPaddingDiv";
 
 export const CreateTaskPage = () => {
   const { control, onSubmit } = useCreateTaskForm();
@@ -20,110 +19,114 @@ export const CreateTaskPage = () => {
   return (
     <div aria-label="Create Task Page">
       <PageWithNotifications title="Create Task">
-        <Form onSubmit={onSubmit}>
-          <FormLayout>
-            <TextField<CreateTaskFormState>
-              name="title"
-              label="Title"
-              type="text"
-              requiredIndicator
-              autoComplete="off"
-              control={control}
-            />
+        <Layout.Section>
+          <FormPaddingDiv>
+            <Form onSubmit={onSubmit}>
+              <FormLayout>
+                <TextField<CreateTaskFormState>
+                  name="title"
+                  label="Title"
+                  type="text"
+                  requiredIndicator
+                  autoComplete="off"
+                  control={control}
+                />
 
-            <TextField<CreateTaskFormState>
-              name="budget"
-              label="Budget"
-              type="currency"
-              requiredIndicator
-              autoComplete="off"
-              control={control}
-            />
+                <TextField<CreateTaskFormState>
+                  name="budget"
+                  label="Budget"
+                  type="currency"
+                  requiredIndicator
+                  autoComplete="off"
+                  control={control}
+                />
 
-            <Select<CreateTaskFormState>
-              options={TaskCategorySchema.options}
-              label="Category"
-              requiredIndicator
-              name="category"
-              control={control}
-            />
+                <Select<CreateTaskFormState>
+                  options={TaskCategorySchema.options}
+                  label="Category"
+                  requiredIndicator
+                  name="category"
+                  control={control}
+                />
 
-            <TextField<CreateTaskFormState>
-              name="details"
-              label="Details"
-              requiredIndicator
-              autoComplete="off"
-              control={control}
-            />
+                <TextField<CreateTaskFormState>
+                  name="details"
+                  label="Details"
+                  requiredIndicator
+                  autoComplete="off"
+                  control={control}
+                />
 
-            <TextField<CreateTaskFormState>
-              name="dueDate"
-              label="Due Date"
-              type="date"
-              requiredIndicator
-              autoComplete="off"
-              control={control}
-            />
+                <TextField<CreateTaskFormState>
+                  name="dueDate"
+                  label="Due Date"
+                  type="date"
+                  requiredIndicator
+                  autoComplete="off"
+                  control={control}
+                />
 
-            <Select<CreateTaskFormState>
-              name="timeOfArrival"
-              label="Time of Arrival"
-              requiredIndicator
-              options={TaskTimeOfArrivalSchema.options}
-              control={control}
-            />
-            <Select<CreateTaskFormState>
-              name="timeEstimate"
-              label="Estimated Time"
-              requiredIndicator
-              options={TaskTimeEstimateSchema.options}
-              control={control}
-            />
+                <Select<CreateTaskFormState>
+                  name="timeOfArrival"
+                  label="Time of Arrival"
+                  requiredIndicator
+                  options={TaskTimeOfArrivalSchema.options}
+                  control={control}
+                />
+                <Select<CreateTaskFormState>
+                  name="timeEstimate"
+                  label="Estimated Time"
+                  requiredIndicator
+                  options={TaskTimeEstimateSchema.options}
+                  control={control}
+                />
 
-            <Text as="h3" variant="headingMd">
-              Address:
-            </Text>
-            <TextField<CreateTaskFormState>
-              name="location.line1"
-              label="Line 1"
-              requiredIndicator
-              autoComplete="off"
-              control={control}
-            />
-            <TextField<CreateTaskFormState>
-              name="location.line2"
-              label="Line 2"
-              autoComplete="off"
-              control={control}
-            />
-            <FormLayout.Group condensed>
-              <TextField<CreateTaskFormState>
-                name="location.city"
-                label="City"
-                requiredIndicator
-                autoComplete="off"
-                control={control}
-              />
-              <Select<CreateTaskFormState>
-                name="location.state"
-                label="State"
-                requiredIndicator
-                options={StateSchema.options}
-                control={control}
-              />
-              <TextField<CreateTaskFormState>
-                name="location.postal_code"
-                label="Postcode"
-                requiredIndicator
-                autoComplete="off"
-                control={control}
-              />
-            </FormLayout.Group>
-            <Button primary submit size="large">
-              Submit
-            </Button>
-          </FormLayout>
-        </Form>
+                <Text as="h3" variant="headingMd">
+                  Address:
+                </Text>
+                <TextField<CreateTaskFormState>
+                  name="location.line1"
+                  label="Line 1"
+                  requiredIndicator
+                  autoComplete="off"
+                  control={control}
+                />
+                <TextField<CreateTaskFormState>
+                  name="location.line2"
+                  label="Line 2"
+                  autoComplete="off"
+                  control={control}
+                />
+                <FormLayout.Group condensed>
+                  <TextField<CreateTaskFormState>
+                    name="location.city"
+                    label="City"
+                    requiredIndicator
+                    autoComplete="off"
+                    control={control}
+                  />
+                  <Select<CreateTaskFormState>
+                    name="location.state"
+                    label="State"
+                    requiredIndicator
+                    options={StateSchema.options}
+                    control={control}
+                  />
+                  <TextField<CreateTaskFormState>
+                    name="location.postal_code"
+                    label="Postcode"
+                    requiredIndicator
+                    autoComplete="off"
+                    control={control}
+                  />
+                </FormLayout.Group>
+                <Button primary submit size="large">
+                  Submit
+                </Button>
+              </FormLayout>
+            </Form>
+          </FormPaddingDiv>
+        </Layout.Section>
       </PageWithNotifications>
     </div>
   );

--- a/src/domains/users/CustomerSignUp/components/SignUpPage.tsx
+++ b/src/domains/users/CustomerSignUp/components/SignUpPage.tsx
@@ -6,13 +6,13 @@ import {
   Checkbox,
   Form,
   FormLayout,
+  Layout,
   Text,
 } from "@shopify/polaris";
-import {
-  PageWithNotifications,
-} from "src/common/features/notifications";
+import { PageWithNotifications } from "src/common/features/notifications";
 import { TextField } from "src/components/TextField";
 import { useSignUpForm, SignUpFormState } from "../hooks";
+import { FormPaddingDiv } from "src/components/FormPaddingDiv";
 
 export const SignUpPage = () => {
   const { control, onSubmit } = useSignUpForm();
@@ -20,58 +20,62 @@ export const SignUpPage = () => {
 
   return (
     <PageWithNotifications title="Sign Up">
-      <Form onSubmit={onSubmit}>
-        <FormLayout>
-          <TextField<SignUpFormState>
-            name="name"
-            label="Name"
-            autoComplete="name"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            name="email"
-            label="Email"
-            type="email"
-            autoComplete="email"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            id="password"
-            name="password"
-            label="Password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="new-password"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            id="passwordConfirm"
-            name="passwordConfirm"
-            label="Confirm Password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="new-password"
-            control={control}
-          />
-          <Checkbox
-            label="Show Password"
-            checked={showPassword}
-            onChange={() => setShowPassword(!showPassword)}
-          />
-          <Button primary submit size="large">
-            Submit
-          </Button>
+      <Layout.Section>
+        <FormPaddingDiv>
+          <Form onSubmit={onSubmit}>
+            <FormLayout>
+              <TextField<SignUpFormState>
+                name="name"
+                label="Name"
+                autoComplete="name"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                name="email"
+                label="Email"
+                type="email"
+                autoComplete="email"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                id="password"
+                name="password"
+                label="Password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                id="passwordConfirm"
+                name="passwordConfirm"
+                label="Confirm Password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                control={control}
+              />
+              <Checkbox
+                label="Show Password"
+                checked={showPassword}
+                onChange={() => setShowPassword(!showPassword)}
+              />
+              <Button primary submit size="large">
+                Submit
+              </Button>
 
-          <Text as="h2" variant="headingSm">
-            Want to earn money on Tasks instead?{" "}
-            <Link
-              href="/providers/signup"
-              className="Polaris-Link"
-              data-polaris-unstyled="true"
-            >
-              Sign Up as Provider.
-            </Link>
-          </Text>
-        </FormLayout>
-      </Form>
+              <Text as="h2" variant="headingSm">
+                Want to earn money on Tasks instead?{" "}
+                <Link
+                  href="/providers/signup"
+                  className="Polaris-Link"
+                  data-polaris-unstyled="true"
+                >
+                  Sign Up as Provider.
+                </Link>
+              </Text>
+            </FormLayout>
+          </Form>
+        </FormPaddingDiv>
+      </Layout.Section>
     </PageWithNotifications>
   );
 };

--- a/src/domains/users/Login/LoginPage.tsx
+++ b/src/domains/users/Login/LoginPage.tsx
@@ -1,15 +1,23 @@
 import { useState } from "react";
-import { signIn as nextAuthSignIn } from "next-auth/react";
 import z from "zod";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import Link from "next/link";
 
-import { Button, Checkbox, Form, FormLayout, Text } from "@shopify/polaris";
+import {
+  Button,
+  Checkbox,
+  Form,
+  FormLayout,
+  Layout,
+  Text,
+} from "@shopify/polaris";
 import { PageWithNotifications } from "src/common/features/notifications";
 import { routerPush } from "@Utils/router";
+
 import { TextField } from "src/components/TextField";
 import { signIn } from "../common/api";
+import { FormPaddingDiv } from "src/components/FormPaddingDiv";
 
 const formSchema = z.object({
   email: z
@@ -37,42 +45,46 @@ export const LoginPage = () => {
 
   return (
     <PageWithNotifications title="Login">
-      <Form onSubmit={handleSubmit(handleLogin)}>
-        <FormLayout>
-          <TextField<LoginFormState>
-            name="email"
-            label="Email"
-            type="email"
-            autoComplete="email"
-            control={control}
-          />
-          <TextField<LoginFormState>
-            name="password"
-            label="Password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="password"
-            control={control}
-          />
-          <Checkbox
-            label="Show Password"
-            checked={showPassword}
-            onChange={() => setShowPassword(!showPassword)}
-          />
-          <Button primary submit size="large">
-            Submit
-          </Button>
-          <Text as="h2" variant="headingSm">
-            If you don&apos;t have an account,{" "}
-            <Link
-              href="/signup"
-              className="Polaris-Link"
-              data-polaris-unstyled="true"
-            >
-              Sign Up here.
-            </Link>
-          </Text>
-        </FormLayout>
-      </Form>
+      <Layout.Section>
+        <FormPaddingDiv>
+          <Form onSubmit={handleSubmit(handleLogin)}>
+            <FormLayout>
+              <TextField<LoginFormState>
+                name="email"
+                label="Email"
+                type="email"
+                autoComplete="email"
+                control={control}
+              />
+              <TextField<LoginFormState>
+                name="password"
+                label="Password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="password"
+                control={control}
+              />
+              <Checkbox
+                label="Show Password"
+                checked={showPassword}
+                onChange={() => setShowPassword(!showPassword)}
+              />
+              <Button primary submit size="large">
+                Submit
+              </Button>
+              <Text as="h2" variant="headingSm">
+                If you don&apos;t have an account,{" "}
+                <Link
+                  href="/signup"
+                  className="Polaris-Link"
+                  data-polaris-unstyled="true"
+                >
+                  Sign Up here.
+                </Link>
+              </Text>
+            </FormLayout>
+          </Form>
+        </FormPaddingDiv>
+      </Layout.Section>
     </PageWithNotifications>
   );
 };

--- a/src/domains/users/ProviderSignUp/components/ProviderSignUpPage.tsx
+++ b/src/domains/users/ProviderSignUp/components/ProviderSignUpPage.tsx
@@ -5,13 +5,13 @@ import {
   Checkbox,
   Form,
   FormLayout,
+  Layout,
   Text,
 } from "@shopify/polaris";
-import {
-  PageWithNotifications,
-} from "src/common/features/notifications";
+import { PageWithNotifications } from "src/common/features/notifications";
 import { TextField } from "src/components/TextField";
 import { useProviderSignUpForm, SignUpFormState } from "../hooks";
+import { FormPaddingDiv } from "src/components/FormPaddingDiv";
 
 export const ProviderSignUpPage = () => {
   const { control, onSubmit } = useProviderSignUpForm();
@@ -19,58 +19,62 @@ export const ProviderSignUpPage = () => {
 
   return (
     <PageWithNotifications title="Provider Sign Up">
-      <Form onSubmit={onSubmit}>
-        <FormLayout>
-          <TextField<SignUpFormState>
-            name="name"
-            label="Name"
-            autoComplete="name"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            name="email"
-            label="Email"
-            type="email"
-            autoComplete="email"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            id="password"
-            name="password"
-            label="Password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="new-password"
-            control={control}
-          />
-          <TextField<SignUpFormState>
-            id="passwordConfirm"
-            name="passwordConfirm"
-            label="Confirm Password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="new-password"
-            control={control}
-          />
-          <Checkbox
-            label="Show Password"
-            checked={showPassword}
-            onChange={() => setShowPassword(!showPassword)}
-          />
-          <Button primary submit size="large">
-            Submit
-          </Button>
+      <Layout.Section>
+        <FormPaddingDiv>
+          <Form onSubmit={onSubmit}>
+            <FormLayout>
+              <TextField<SignUpFormState>
+                name="name"
+                label="Name"
+                autoComplete="name"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                name="email"
+                label="Email"
+                type="email"
+                autoComplete="email"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                id="password"
+                name="password"
+                label="Password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                control={control}
+              />
+              <TextField<SignUpFormState>
+                id="passwordConfirm"
+                name="passwordConfirm"
+                label="Confirm Password"
+                type={showPassword ? "text" : "password"}
+                autoComplete="new-password"
+                control={control}
+              />
+              <Checkbox
+                label="Show Password"
+                checked={showPassword}
+                onChange={() => setShowPassword(!showPassword)}
+              />
+              <Button primary submit size="large">
+                Submit
+              </Button>
 
-          <Text as="h2" variant="headingSm">
-            Need help with a Task Instead?{" "}
-            <Link
-              href="/signup"
-              className="Polaris-Link"
-              data-polaris-unstyled="true"
-            >
-              Sign Up as Customer.
-            </Link>
-          </Text>
-        </FormLayout>
-      </Form>
+              <Text as="h2" variant="headingSm">
+                Need help with a Task Instead?{" "}
+                <Link
+                  href="/signup"
+                  className="Polaris-Link"
+                  data-polaris-unstyled="true"
+                >
+                  Sign Up as Customer.
+                </Link>
+              </Text>
+            </FormLayout>
+          </Form>
+        </FormPaddingDiv>
+      </Layout.Section>
     </PageWithNotifications>
   );
 };


### PR DESCRIPTION
This commit adds styling that fixes the follow forms from overflowing on mobile viewports:
- Login
- Customer Signup Page
- Provider Signup Page
- Create Task Page

## Screenshots:

### Login Page

[Mobile Before](https://user-images.githubusercontent.com/8443215/225859204-43cf2ff4-31ea-4dc5-a2a5-b0e75c2ea4e0.png)
[Mobile After](https://user-images.githubusercontent.com/8443215/225858887-b19089fa-ca94-41d9-90c0-67dc29463040.png)

### Customer Signup Page

[Mobile Before](https://user-images.githubusercontent.com/8443215/225859213-68aba1f0-f654-4187-abd3-e955d1cddf6b.png)
[Mobile After](https://user-images.githubusercontent.com/8443215/225859044-66228289-223b-4e4a-947e-8d8fa81fe90c.png)

### Provider Signup Page

[Mobile Before](https://user-images.githubusercontent.com/8443215/225859221-29f48d55-2c4b-47e6-b64b-96891dd5d508.png)
[Mobile After](https://user-images.githubusercontent.com/8443215/225859033-ab127145-ba85-4ea5-bdcb-80b31ead3dd8.png)

### Create Task Page

[Mobile Before](https://user-images.githubusercontent.com/8443215/225858443-8679d951-ec50-4784-a2a4-f050e4e81bb8.png)
[Mobile After](https://user-images.githubusercontent.com/8443215/225858793-46091ea1-9cec-4dcf-9436-bfbdf54d6da3.png)

