### PR TITLE
Feat: Handle API Results via the NotifcationsContext

### DIFF
--- a/src/common/features/notifications/components/PageWithNotifications.tsx
+++ b/src/common/features/notifications/components/PageWithNotifications.tsx
@@ -9,8 +9,8 @@ export function PageWithNotifications({
   children,
   ...otherProps
 }: PageWithNotificationsProps) {
-  const { apiEvents, dispatchApiEvents } = useNotifications();
-  const events = [...apiEvents.values()];
+  const { notifications, dispatchNotifications } = useNotifications();
+  const events = [...notifications.values()];
 
   return (
     <Page {...otherProps}>
@@ -23,7 +23,7 @@ export function PageWithNotifications({
               title={event.title}
               status={event.status}
               onDismiss={() => {
-                dispatchApiEvents({
+                dispatchNotifications({
                   type: "delete",
                   id: event.id,
                 });
@@ -40,7 +40,7 @@ export function PageWithNotifications({
               content={event.title}
               error={event.isError}
               onDismiss={() => {
-                dispatchApiEvents({
+                dispatchNotifications({
                   type: "delete",
                   id: event.id,
                 });

--- a/src/common/features/notifications/hooks/NotificationsContext.tsx
+++ b/src/common/features/notifications/hooks/NotificationsContext.tsx
@@ -48,8 +48,8 @@ export function notificationsReducer(
 }
 
 export type NotificationsContextValues = {
-  apiEvents: NotifcationsMap;
-  dispatchApiEvents: Dispatch<NotificationsAction>;
+  notifications: NotifcationsMap;
+  dispatchNotifications: Dispatch<NotificationsAction>;
 };
 
 const NotificationsContext = createContext<
@@ -84,8 +84,8 @@ export function NotificationsProvider({
   return (
     <NotificationsContext.Provider
       value={{
-        apiEvents: notifications,
-        dispatchApiEvents: dispatchNotifications,
+        notifications: notifications,
+        dispatchNotifications: dispatchNotifications,
       }}
     >
       {children}

--- a/src/domains/billing/Checkout/components/CheckoutForm.tsx
+++ b/src/domains/billing/Checkout/components/CheckoutForm.tsx
@@ -37,7 +37,7 @@ export const CheckoutForm = ({ isPageLoading, taskId }: CheckoutFormProps) => {
   const elements = useElements();
   const [isLoading, setIsLoading] = useState(true);
   const { clientSecret } = useCreatePaymentIntent(taskId, setIsLoading);
-  const { dispatchApiEvents } = useNotifications();
+  const { dispatchNotifications } = useNotifications();
   const isStripeLoading = !stripe ? true : false;
 
   const disabled = isPageLoading || isLoading;
@@ -62,7 +62,7 @@ export const CheckoutForm = ({ isPageLoading, taskId }: CheckoutFormProps) => {
         ? result.error.message
         : "An unexpected error occurred.";
 
-      dispatchApiEvents({
+      dispatchNotifications({
         type: "set",
         event: createNotification({
           isError: true,
@@ -73,7 +73,7 @@ export const CheckoutForm = ({ isPageLoading, taskId }: CheckoutFormProps) => {
         }),
       });
     } else if (result.paymentIntent.status === "succeeded") {
-      dispatchApiEvents({
+      dispatchNotifications({
         type: "set",
         event: createNotification({
           isError: false,

--- a/src/domains/billing/Checkout/hooks/useCheckoutTaskFetch.tsx
+++ b/src/domains/billing/Checkout/hooks/useCheckoutTaskFetch.tsx
@@ -6,7 +6,7 @@ import { createNotification } from "src/common/features/notifications/utils";
 export const getCheckoutTaskURL = `${process.env.NEXT_PUBLIC_API_URL}api/v1/checkout`;
 
 export const useCheckoutTaskFetch = (taskId: string) => {
-  const { dispatchApiEvents } = useNotifications();
+  const { dispatchNotifications } = useNotifications();
 
   return useQuery({
     retry: false,
@@ -24,7 +24,7 @@ export const useCheckoutTaskFetch = (taskId: string) => {
       return task;
     },
     onError: (error: Error) => {
-      dispatchApiEvents({
+      dispatchNotifications({
         type: "set",
         event: createNotification({
           isError: true,

--- a/src/domains/tasks/CreateTask/hooks/useCreateTaskForm.tsx
+++ b/src/domains/tasks/CreateTask/hooks/useCreateTaskForm.tsx
@@ -3,21 +3,51 @@ import { useForm } from "react-hook-form";
 import { CreateTaskFormSchema, CreateTaskFormState } from "../types";
 import { createTask } from "../api";
 import { routerPush } from "@Utils/router";
-
-export const submitHandler = async (data: CreateTaskFormState) => {
-  try {
-    const response = await createTask(data);
-    routerPush("/tasks");
-  } catch (error: any) {
-    console.error(error);
-  }
-};
+import { useNotifications } from "src/common/features/notifications";
+import { createNotification } from "src/common/features/notifications/utils";
 
 export const useCreateTaskForm = () => {
+  const { dispatchNotifications } = useNotifications();
   const { control, handleSubmit } = useForm<CreateTaskFormState>({
     mode: "onBlur",
     resolver: zodResolver(CreateTaskFormSchema),
   });
+
+  const submitHandler = async (data: CreateTaskFormState) => {
+    dispatchNotifications({ type: "clear" });
+
+    try {
+      await createTask(data).then((res) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: false,
+            title: "Task created",
+            type: "toast",
+            status: "success",
+            source: "Create Task Success",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      });
+
+      routerPush("/tasks");
+    } catch (error: any) {
+      const action = {
+        type: "set",
+        event: createNotification({
+          isError: true,
+          title: error.response.data.message,
+          type: "notification",
+          status: "critical",
+          source: "Create Task Failure",
+        }),
+      } as const;
+
+      dispatchNotifications(action);
+    }
+  };
 
   return { control, onSubmit: handleSubmit(submitHandler) };
 };

--- a/src/domains/tasks/MakeOffer/components/MakeOfferForm.tsx
+++ b/src/domains/tasks/MakeOffer/components/MakeOfferForm.tsx
@@ -3,13 +3,54 @@ import { Button, Form, FormLayout } from "@shopify/polaris";
 import { TextField } from "src/components";
 
 import { useMakeAnOfferForm } from "../hooks/useMakeOfferForm";
-import { MakeAnOfferFormState, MakeAnOfferSubmitHandler } from "../types";
+import { MakeAnOfferFormState } from "../types";
+import { createOffer } from "../api";
+import { useNotifications } from "src/common/features/notifications";
+import { createNotification } from "src/common/features/notifications/utils";
 
 type MakeAnOfferFormProps = {
-  submitHandler: MakeAnOfferSubmitHandler;
+  taskId: string;
+  onClose: () => void;
 };
 
-export const MakeAnOfferForm = ({ submitHandler }: MakeAnOfferFormProps) => {
+export const MakeAnOfferForm = ({ taskId, onClose }: MakeAnOfferFormProps) => {
+  const { dispatchNotifications } = useNotifications();
+
+  const submitHandler = async (data: MakeAnOfferFormState) => {
+    dispatchNotifications({ type: "clear" });
+    createOffer(taskId, data)
+      .then((res) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: false,
+            title: "Successfully created Offer",
+            type: "toast",
+            status: "success",
+            source: "Make Offer Success",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+
+        onClose();
+      })
+      .catch((err) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: true,
+            title: err.response.data.message,
+            type: "toast",
+            status: "critical",
+            source: "Make Offer Failure",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      });
+  };
+
   const { control, onSubmit } = useMakeAnOfferForm(submitHandler);
 
   return (

--- a/src/domains/tasks/MakeOffer/components/MakeOfferModal.tsx
+++ b/src/domains/tasks/MakeOffer/components/MakeOfferModal.tsx
@@ -1,8 +1,6 @@
 import { Modal } from "@shopify/polaris";
 
 import { MakeAnOfferForm } from "./MakeOfferForm";
-import { createOffer } from "../api";
-import { MakeAnOfferFormState } from "../types";
 
 type MakeAnOfferModalProps = {
   taskId: string;
@@ -13,16 +11,11 @@ export const MakeAnOfferModal = ({
   taskId,
   onClose,
 }: MakeAnOfferModalProps) => {
-  const submitHandler = async (data: MakeAnOfferFormState) => {
-    const response = await createOffer(taskId, data);
-    onClose();
-  };
-
   return (
     <div>
       <Modal open={true} title="Make an Offer" onClose={onClose}>
         <Modal.Section>
-          <MakeAnOfferForm submitHandler={submitHandler} />
+          <MakeAnOfferForm taskId={taskId} onClose={onClose} />
         </Modal.Section>
       </Modal>
     </div>

--- a/src/domains/tasks/ViewOffers/api/index.tsx
+++ b/src/domains/tasks/ViewOffers/api/index.tsx
@@ -5,10 +5,9 @@ export const getOffersUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`;
 export const getTasksUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`;
 
 export async function completeOfferMutation(taskId: string) {
-  axios
-    .patch(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks/${taskId}/completed`)
-    .then((response) => console.log(response))
-    .catch((error) => console.log(error));
+  return axios.patch(
+    `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks/${taskId}/completed`
+  );
 }
 
 export async function getTaskQuery(taskId: string) {

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -117,7 +117,7 @@ export type ViewOffersPageProps = {
 };
 
 export function ViewOffersPage({ status }: ViewOffersPageProps) {
-  const { dispatchApiEvents } = useNotifications();
+  const { dispatchNotifications } = useNotifications();
 
   const [offers, setOffers] = useState(new Array<Offer>());
   const [selectedTask, setSelectedTask] = useState<Task | undefined>();
@@ -132,7 +132,7 @@ export function ViewOffersPage({ status }: ViewOffersPageProps) {
       })
       .catch((error) => {
         if (error instanceof AxiosError && error.response) {
-          dispatchApiEvents({
+          dispatchNotifications({
             type: "set",
             event: createNotification({
               isError: true,
@@ -169,13 +169,13 @@ export function ViewOffersPage({ status }: ViewOffersPageProps) {
             source: "Api Error",
           });
 
-          dispatchApiEvents({
+          dispatchNotifications({
             type: "set",
             event: apiEvent,
           });
         }
       });
-  }, [dispatchApiEvents, status]);
+  }, [dispatchNotifications, status]);
 
   return (
     <StyledDiv aria-label="View Offers Page">

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -11,6 +11,7 @@ import {
   Text,
   TextContainer,
 } from "@shopify/polaris";
+import { AxiosError } from "axios";
 import styled from "styled-components";
 
 import { OfferStatusBadge } from "@Tasks/common/components";
@@ -26,7 +27,6 @@ import {
   useNotifications,
 } from "src/common/features/notifications";
 
-import { AxiosError } from "axios";
 import { createNotification } from "src/common/features/notifications/utils";
 
 const TaskCard = dynamic(() =>
@@ -41,6 +41,39 @@ export function OfferCard({
   onViewTaskClick(): void;
 }) {
   const showMarkAsCompleteButton = offer.status === "accepted";
+  const { dispatchNotifications } = useNotifications();
+
+  const onCompleteTaskClick = () => {
+    completeOfferMutation(offer.task)
+      .then((res) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: false,
+            title: "Task marked as completed",
+            type: "toast",
+            status: "success",
+            source: "Mark Task as Completed Success",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      })
+      .catch((err: any) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: true,
+            title: err.response.data.message,
+            type: "toast",
+            status: "critical",
+            source: "Mark Task as Completed Failure",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      });
+  };
 
   return (
     <Card
@@ -74,9 +107,7 @@ export function OfferCard({
                 View Task Details
               </Button>
               {showMarkAsCompleteButton ? (
-                <Button onClick={() => completeOfferMutation(offer.task)}>
-                  Mark as Complete
-                </Button>
+                <Button onClick={onCompleteTaskClick}>Mark as Complete</Button>
               ) : null}
             </ButtonGroup>
           </Stack>

--- a/src/domains/tasks/ViewTasks/api/index.tsx
+++ b/src/domains/tasks/ViewTasks/api/index.tsx
@@ -1,15 +1,10 @@
 import axios from "axios";
 
 export const acceptOfferMutation = (taskId: string, offerId: string) => {
-  axios
-    .post(`${process.env.NEXT_PUBLIC_API_URL}api/v1/acceptoffer/`, {
-      taskId,
-      offerId,
-    })
-    .then((response) => {
-      console.log(response);
-    })
-    .catch((error) => console.log(error));
+  return axios.post(`${process.env.NEXT_PUBLIC_API_URL}api/v1/acceptoffer/`, {
+    taskId,
+    offerId,
+  });
 };
 
 export const getOffersOfTaskQuery = (taskId: string) => {

--- a/src/domains/tasks/ViewTasks/components/OffersTable.tsx
+++ b/src/domains/tasks/ViewTasks/components/OffersTable.tsx
@@ -15,6 +15,8 @@ import { Offer, OfferStatus } from "@Tasks/common/types";
 
 import { acceptOfferMutation } from "../api";
 import { OfferStatusBadge } from "@Tasks/common/components";
+import { createNotification } from "src/common/features/notifications/utils";
+import { useNotifications } from "src/common/features/notifications";
 
 type IndexTableRowProps = ComponentProps<typeof IndexTable.Row>;
 
@@ -54,6 +56,7 @@ export const OfferItemRow = ({ offer, ...props }: OfferItemRowProps) => {
 export const OffersTable = ({ offers }: { offers: Array<Offer> }) => {
   const { handleSelectionChange, selectedResources, clearSelection } =
     useIndexResourceState(offers);
+  const { dispatchNotifications } = useNotifications();
 
   const customHandleSelectionChange = (
     selectionType: IndexTableSelectionType,
@@ -93,7 +96,35 @@ export const OffersTable = ({ offers }: { offers: Array<Offer> }) => {
           offerId: selectedResources[0],
         };
 
-        acceptOfferMutation(body.taskId, body.offerId);
+        acceptOfferMutation(body.taskId, body.offerId)
+          .then((response) => {
+            const action = {
+              type: "set",
+              event: createNotification({
+                status: "success",
+                isError: false,
+                title: `Successfully accepted offer.`,
+                type: "toast",
+                source: "Accept Offer Success",
+              }),
+            } as const;
+
+            dispatchNotifications(action);
+          })
+          .catch((error) => {
+            const action = {
+              type: "set",
+              event: createNotification({
+                status: "critical",
+                isError: true,
+                title: "Failed to select offer, please try again later.",
+                type: "toast",
+                source: "Accept Offer Failure",
+              }),
+            } as const;
+
+            dispatchNotifications(action);
+          });
       },
     },
   ];

--- a/src/domains/tasks/ViewTasks/components/TasksPage.tsx
+++ b/src/domains/tasks/ViewTasks/components/TasksPage.tsx
@@ -45,6 +45,7 @@ export const OffersSection = ({ task }: { task: Task }) => {
 
   const [showOffers, setShowOffers] = useState(false);
   const [updatedTask, setUpdatedTask] = useState<any>(task);
+  const { dispatchNotifications } = useNotifications();
 
   useEffect(() => {
     getOffersOfTaskQuery(task.id)
@@ -55,8 +56,21 @@ export const OffersSection = ({ task }: { task: Task }) => {
       })
       .catch((error: any) => {
         setUpdatedTask(task);
+
+        const action = {
+          type: "set",
+          event: createNotification({
+            status: "critical",
+            isError: true,
+            title: error.response.data.message,
+            type: "notification",
+            source: "Get Offers of Task Failure",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
       });
-  }, [task, taskId]);
+  }, [dispatchNotifications, task, taskId]);
 
   return (
     <Card.Section

--- a/src/domains/tasks/ViewTasks/components/TasksPage.tsx
+++ b/src/domains/tasks/ViewTasks/components/TasksPage.tsx
@@ -70,16 +70,18 @@ export const OffersSection = ({ task }: { task: Task }) => {
 export const TaskCard = ({ task }: { task: Task }) => {
   const { location } = task;
   const isCompleted = task.status === "completed";
-  const isDue = task.paymentStatus === "payment_due" || task.paymentStatus === "pay_decline"
+  const isDue =
+    task.paymentStatus === "payment_due" ||
+    task.paymentStatus === "pay_decline";
 
-  const checkoutButton = isCompleted && isDue
-    ? {
-        content: "Finalize Payment",
-        onAction: () => routerPush(`/checkout/${task.id}`),
-      }
-    : undefined;
+  const checkoutButton =
+    isCompleted && isDue
+      ? {
+          content: "Finalize Payment",
+          onAction: () => routerPush(`/checkout/${task.id}`),
+        }
+      : undefined;
 
-  console.log("isDue", {isDue})
   return (
     <Layout.Section>
       <article aria-label="Task Card">

--- a/src/domains/users/CustomerSignUp/hooks/useSignUpForm.tsx
+++ b/src/domains/users/CustomerSignUp/hooks/useSignUpForm.tsx
@@ -4,6 +4,8 @@ import { z } from "zod";
 
 import { routerPush } from "@Utils/index";
 import { createCustomerUser } from "@Users/common/api";
+import { useNotifications } from "src/common/features/notifications";
+import { createNotification } from "src/common/features/notifications/utils";
 
 export const formSchema = z
   .object({
@@ -23,16 +25,48 @@ export const formSchema = z
 
 export type SignUpFormState = z.infer<typeof formSchema>;
 
-export const submitHandler = async (data: SignUpFormState) => {
-  await createCustomerUser(data);
-  routerPush("/");
-};
-
 export const useSignUpForm = () => {
+  const { dispatchNotifications } = useNotifications();
   const { control, handleSubmit } = useForm<SignUpFormState>({
     mode: "onBlur",
     resolver: zodResolver(formSchema),
   });
+
+  const submitHandler = async (data: SignUpFormState) => {
+    dispatchNotifications({ type: "clear" });
+    await createCustomerUser(data)
+      .then((res) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: false,
+            title:
+              "Thank you for signing up. Please login with your account details.",
+            type: "toast",
+            status: "success",
+            source: "Customer Signup Success",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+
+        routerPush("/login");
+      })
+      .catch((err) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: true,
+            title: err.response.data.message,
+            type: "notification",
+            status: "critical",
+            source: "Customer Signup Failure",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      });
+  };
 
   return { control, onSubmit: handleSubmit(submitHandler) };
 };

--- a/src/domains/users/Login/LoginPage.tsx
+++ b/src/domains/users/Login/LoginPage.tsx
@@ -21,19 +21,19 @@ const formSchema = z.object({
 });
 export type LoginFormState = z.infer<typeof formSchema>;
 
-const handleLogin = async (formValues: LoginFormState) => {
-  const data = await signIn(formValues);
-  if (!data?.error && data?.url) return routerPush(data?.url);
-
-  return data;
-};
-
 export const LoginPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const { control, handleSubmit } = useForm<LoginFormState>({
     mode: "onBlur",
     resolver: zodResolver(formSchema),
   });
+
+  const handleLogin = async (formValues: LoginFormState) => {
+    const data = await signIn(formValues);
+    if (!data?.error && data?.url) return routerPush(data?.url);
+
+    return data;
+  };
 
   return (
     <PageWithNotifications title="Login">

--- a/src/domains/users/Login/LoginPage.tsx
+++ b/src/domains/users/Login/LoginPage.tsx
@@ -75,6 +75,8 @@ export const LoginPage = () => {
   };
 
   const handleLogin = async (formValues: LoginFormState) => {
+    dispatchNotifications({ type: "clear" });
+
     const data = await signIn(formValues).then((data) => {
       dispatchNotifications(handleLoginResult(data));
 

--- a/src/domains/users/Login/LoginPage.tsx
+++ b/src/domains/users/Login/LoginPage.tsx
@@ -12,11 +12,16 @@ import {
   Layout,
   Text,
 } from "@shopify/polaris";
-import { PageWithNotifications } from "src/common/features/notifications";
+import {
+  NotificationsAction,
+  PageWithNotifications,
+  useNotifications,
+} from "src/common/features/notifications";
 import { routerPush } from "@Utils/router";
 
 import { TextField } from "src/components/TextField";
 import { signIn } from "../common/api";
+import { createNotification } from "src/common/features/notifications/utils";
 import { FormPaddingDiv } from "src/components/FormPaddingDiv";
 
 const formSchema = z.object({
@@ -31,13 +36,29 @@ export type LoginFormState = z.infer<typeof formSchema>;
 
 export const LoginPage = () => {
   const [showPassword, setShowPassword] = useState(false);
+  const { dispatchNotifications } = useNotifications();
   const { control, handleSubmit } = useForm<LoginFormState>({
     mode: "onBlur",
     resolver: zodResolver(formSchema),
   });
 
   const handleLogin = async (formValues: LoginFormState) => {
-    const data = await signIn(formValues);
+    const data = await signIn(formValues).then((data) => {
+      const action: NotificationsAction = {
+        type: "set",
+        event: createNotification({
+          isError: false,
+          title: "Successfully logged in.",
+          type: "toast",
+          status: "success",
+          source: "Login Success",
+        }),
+      };
+
+      dispatchNotifications(action);
+
+      return data;
+    });
     if (!data?.error && data?.url) return routerPush(data?.url);
 
     return data;

--- a/src/domains/users/common/api/index.tsx
+++ b/src/domains/users/common/api/index.tsx
@@ -41,14 +41,10 @@ export const createUser = async (user: SignUpFormState) => {
  * Consolidated signup request for creating a new User and a Stripe Customer
  */
 export const createCustomerUser = async (user: SignUpFormState) => {
-  const signUpResponse = await axios.post(
+  return await axios.post(
     `${process.env.NEXT_PUBLIC_API_URL}api/v1/customers`,
     user
   );
-
-  debugger;
-
-  return signUpResponse.data.data;
 };
 
 export const signInAndRedirectHome = async (


### PR DESCRIPTION
This pull request adds implementation that renders Notification Banners or Toasts depending on a HTTP request response.

## Screenshots
[Listings (Mobile) - Tasks Failing to Load](https://user-images.githubusercontent.com/8443215/226086244-5dc6e606-251f-4e54-9300-687cdcd3695a.png)
[Make an Offer Modal (Mobile) - Invalid Offer amount](https://user-images.githubusercontent.com/8443215/226086259-7ae68b50-8b07-4a3b-870a-468f3dba2580.png)
[Sign Up Form (Mobile) - Missing Input](https://user-images.githubusercontent.com/8443215/226086286-840843d4-24b4-4157-9f8a-577a17e2616b.png)
[Successful Signup (Mobile)](https://user-images.githubusercontent.com/8443215/226086287-28e906bf-6afa-4425-9250-58985d7c918e.png)
[Successful Login (Mobile)](https://user-images.githubusercontent.com/8443215/226086318-54a7db76-8b73-4c29-8857-5c0dc8f43520.png)


Note: Input Validation was turned off to show some of these notifications.
