### PR TITLE
feat: move fetch requests to server side

### DIFF
--- a/src/domains/tasks/ViewListings/components/ListingsPage.tsx
+++ b/src/domains/tasks/ViewListings/components/ListingsPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 
-import axios from "axios";
 import { useSession } from "next-auth/react";
 import { Button, Layout } from "@shopify/polaris";
 
@@ -14,14 +13,7 @@ import {
 
 import { routerPush } from "@Utils/router";
 import { createNotification } from "src/common/features/notifications/utils";
-
-async function getTasks(currentPage: number) {
-  const params = { page: currentPage, limit: 6 };
-
-  return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
-    params,
-  });
-}
+import { getTasks } from "@Tasks/common/api";
 
 export function ListingsPage() {
   const [currentPage, setCurrentPage]: any = useState(1);
@@ -33,7 +25,12 @@ export function ListingsPage() {
   const isProvider = data?.user.providerId ? true : false;
   const isCustomer = data?.user.customerId ? true : false;
 
-  const createTaskButton = <Button primary onClick={() => routerPush("/tasks new")}> Create Task </Button>
+  const createTaskButton = (
+    <Button primary onClick={() => routerPush("/tasks new")}>
+      {" "}
+      Create Task{" "}
+    </Button>
+  );
 
   useEffect(() => {
     if (status === "loading") return;
@@ -68,9 +65,7 @@ export function ListingsPage() {
     <PageWithNotifications
       title="Listings"
       fullWidth
-      primaryAction={
-      isCustomer ? createTaskButton : null
-      }
+      primaryAction={isCustomer ? createTaskButton : null}
     >
       {data ? null : (
         <div

--- a/src/domains/tasks/ViewListings/components/ListingsPage.tsx
+++ b/src/domains/tasks/ViewListings/components/ListingsPage.tsx
@@ -13,7 +13,7 @@ import {
 
 import { routerPush } from "@Utils/router";
 import { createNotification } from "src/common/features/notifications/utils";
-import { getTasks } from "@Tasks/common/api";
+import { getTasksQuery } from "@Tasks/common/api";
 
 export function ListingsPage() {
   const [currentPage, setCurrentPage]: any = useState(1);
@@ -37,7 +37,7 @@ export function ListingsPage() {
 
     dispatchNotifications({ type: "clear" });
 
-    getTasks(currentPage)
+    getTasksQuery(currentPage)
       .then((response) => {
         if (response.data.data.tasks.length == 0) {
           setCurrentPage(currentPage - 1);

--- a/src/domains/tasks/ViewOffers/api/index.tsx
+++ b/src/domains/tasks/ViewOffers/api/index.tsx
@@ -1,7 +1,6 @@
 import { Task, Offer } from "@Tasks/common/types";
 import axios from "axios";
 
-export const getOffersUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`;
 export const getTasksUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`;
 
 export async function completeOfferMutation(taskId: string) {
@@ -16,12 +15,4 @@ export async function getTaskQuery(taskId: string) {
   );
 
   return response.data.data.task as Task;
-}
-
-export async function getOffersOfProviderQuery() {
-  const response = await axios.get(getOffersUrl, {
-    params: { my_offers: true },
-  });
-
-  return response.data.data.offers as Array<Offer>;
 }

--- a/src/domains/tasks/ViewOffers/components/OfferCard.tsx
+++ b/src/domains/tasks/ViewOffers/components/OfferCard.tsx
@@ -1,0 +1,103 @@
+import {
+  Card,
+  Stack,
+  TextContainer,
+  ButtonGroup,
+  Button,
+  EmptyState,
+  Spinner,
+  Text,
+} from "@shopify/polaris";
+
+import {
+  useNotifications,
+  createNotification,
+} from "src/common/features/notifications";
+import { OfferStatusBadge } from "@Tasks/common/components";
+import { Offer } from "@Tasks/common/types";
+
+import { completeOfferMutation } from "../api";
+
+export function OfferCard({
+  offer,
+  onViewTaskClick,
+}: {
+  offer: Offer;
+  onViewTaskClick(): void;
+}) {
+  const showMarkAsCompleteButton = offer.status === "accepted";
+  const { dispatchNotifications } = useNotifications();
+
+  const onCompleteTaskClick = () => {
+    completeOfferMutation(offer.task)
+      .then(() => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: false,
+            title: "Task marked as completed",
+            type: "toast",
+            status: "success",
+            source: "Mark Task as Completed Success",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      })
+      .catch((err: any) => {
+        const action = {
+          type: "set",
+          event: createNotification({
+            isError: true,
+            title: err.response.data.message,
+            type: "toast",
+            status: "critical",
+            source: "Mark Task as Completed Failure",
+          }),
+        } as const;
+
+        dispatchNotifications(action);
+      });
+  };
+
+  return (
+    <Card
+      sectioned
+      title={
+        <Stack>
+          <Stack.Item fill>
+            <Text variant="headingMd" as="h2">
+              Offer
+            </Text>
+          </Stack.Item>
+          <Stack.Item>
+            <OfferStatusBadge status={offer.status} />
+          </Stack.Item>
+        </Stack>
+      }
+    >
+      <Card.Section>
+        <Stack vertical>
+          <TextContainer spacing="tight">
+            <Text as="h3" variant="headingMd">
+              ${offer.offerAmt}
+            </Text>
+            <Text as="p" variant="bodyMd">
+              {offer.comments}
+            </Text>
+          </TextContainer>
+          <Stack distribution="trailing">
+            <ButtonGroup>
+              <Button plain onClick={onViewTaskClick}>
+                View Task Details
+              </Button>
+              {showMarkAsCompleteButton ? (
+                <Button onClick={onCompleteTaskClick}>Mark as Complete</Button>
+              ) : null}
+            </ButtonGroup>
+          </Stack>
+        </Stack>
+      </Card.Section>
+    </Card>
+  );
+}

--- a/src/domains/tasks/ViewOffers/components/TaskCard.tsx
+++ b/src/domains/tasks/ViewOffers/components/TaskCard.tsx
@@ -1,52 +1,85 @@
-import { Card, Stack, Text, TextContainer } from "@shopify/polaris";
+import {
+  Card,
+  EmptyState,
+  Spinner,
+  Stack,
+  Text,
+  TextContainer,
+} from "@shopify/polaris";
 
 import { Task, TaskStatus } from "@Tasks/common/types";
 import { TaskStatusBadge } from "@Tasks/common/components";
 
-export type TaskCardProps = { task: Task };
+export type TaskCardProps = { task?: Task; loading: boolean };
 
-export function TaskCard({ task }: TaskCardProps) {
+/**
+ * This component is shown when a Task has not been selected yet.
+ */
+function EmptyTaskCardBody() {
+  return (
+    <Card sectioned title="View Task Details">
+      <EmptyState image={""}>
+        <Text as="h1" variant="headingMd">
+          To view a task, click on the &quot;View Task Details&quot; link on a
+          task.
+        </Text>
+      </EmptyState>
+    </Card>
+  );
+}
+
+export function TaskCard({ task, loading }: TaskCardProps) {
+  if (!task) {
+    return <EmptyTaskCardBody />;
+  }
+
   const { location } = task;
 
   return (
-    <Card sectioned>
-      <Card.Header
-        title={
-          <Stack>
-            <Stack.Item fill>
-              <Text variant="headingMd" as="h2">
-                {task.title}
+    <Card sectioned title="View Task Details">
+      {loading ? (
+        <Spinner />
+      ) : (
+        <>
+          <Card.Header
+            title={
+              <Stack>
+                <Stack.Item fill>
+                  <Text variant="headingMd" as="h2">
+                    {task.title}
+                  </Text>
+                </Stack.Item>
+                <Stack.Item>
+                  <TaskStatusBadge status={task.status as TaskStatus} />
+                </Stack.Item>
+              </Stack>
+            }
+          />
+          <Card.Section
+            title={
+              <Text as="h3" variant="headingMd">
+                Details
               </Text>
-            </Stack.Item>
-            <Stack.Item>
-              <TaskStatusBadge status={task.status as TaskStatus} />
-            </Stack.Item>
-          </Stack>
-        }
-      />
-      <Card.Section
-        title={
-          <Text as="h3" variant="headingMd">
-            Details
-          </Text>
-        }
-      >
-        <TextContainer spacing="tight">
-          <Text as="h3" variant="headingSm">
-            ${task.budget}
-          </Text>
-          <Text as="p" variant="bodyMd">
-            {task.category}
-          </Text>
-          <Text as="p" variant="bodyMd">
-            {task.details}
-          </Text>
-          <Text as="p" variant="bodyMd">
-            {location.line1} {location.line2}, {location.city} {location.state}{" "}
-            {location.postal_code}
-          </Text>
-        </TextContainer>
-      </Card.Section>
+            }
+          >
+            <TextContainer spacing="tight">
+              <Text as="h3" variant="headingSm">
+                ${task.budget}
+              </Text>
+              <Text as="p" variant="bodyMd">
+                {task.category}
+              </Text>
+              <Text as="p" variant="bodyMd">
+                {task.details}
+              </Text>
+              <Text as="p" variant="bodyMd">
+                {location.line1} {location.line2}, {location.city}{" "}
+                {location.state} {location.postal_code}
+              </Text>
+            </TextContainer>
+          </Card.Section>
+        </>
+      )}
     </Card>
   );
 }

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -1,118 +1,26 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
-import {
-  Button,
-  ButtonGroup,
-  Card,
-  EmptyState,
-  Layout,
-  Spinner,
-  Stack,
-  Text,
-  TextContainer,
-} from "@shopify/polaris";
+import { Card, EmptyState, Layout, Spinner } from "@shopify/polaris";
 import { AxiosError } from "axios";
 import styled from "styled-components";
 
-import { OfferStatusBadge } from "@Tasks/common/components";
-
 import { Offer, Task } from "@Tasks/common/types";
-import { getTaskQuery, completeOfferMutation } from "../api";
+import { getTaskQuery } from "../api";
 import {
   PageWithNotifications,
   useNotifications,
 } from "src/common/features/notifications";
 
 import { createNotification } from "src/common/features/notifications/utils";
+import { OfferCard } from "./OfferCard";
 
 const TaskCard = dynamic(() =>
   import("./TaskCard").then((mod) => mod.TaskCard)
 );
 
-export function OfferCard({
-  offer,
-  onViewTaskClick,
-}: {
-  offer: Offer;
-  onViewTaskClick(): void;
-}) {
-  const showMarkAsCompleteButton = offer.status === "accepted";
-  const { dispatchNotifications } = useNotifications();
-
-  const onCompleteTaskClick = () => {
-    completeOfferMutation(offer.task)
-      .then((res) => {
-        const action = {
-          type: "set",
-          event: createNotification({
-            isError: false,
-            title: "Task marked as completed",
-            type: "toast",
-            status: "success",
-            source: "Mark Task as Completed Success",
-          }),
-        } as const;
-
-        dispatchNotifications(action);
-      })
-      .catch((err: any) => {
-        const action = {
-          type: "set",
-          event: createNotification({
-            isError: true,
-            title: err.response.data.message,
-            type: "toast",
-            status: "critical",
-            source: "Mark Task as Completed Failure",
-          }),
-        } as const;
-
-        dispatchNotifications(action);
-      });
-  };
-
-  return (
-    <Card
-      sectioned
-      title={
-        <Stack>
-          <Stack.Item fill>
-            <Text variant="headingMd" as="h2">
-              Offer
-            </Text>
-          </Stack.Item>
-          <Stack.Item>
-            <OfferStatusBadge status={offer.status} />
-          </Stack.Item>
-        </Stack>
-      }
-    >
-      <Card.Section>
-        <Stack vertical>
-          <TextContainer spacing="tight">
-            <Text as="h3" variant="headingMd">
-              ${offer.offerAmt}
-            </Text>
-            <Text as="p" variant="bodyMd">
-              {offer.comments}
-            </Text>
-          </TextContainer>
-          <Stack distribution="trailing">
-            <ButtonGroup>
-              <Button plain onClick={onViewTaskClick}>
-                View Task Details
-              </Button>
-              {showMarkAsCompleteButton ? (
-                <Button onClick={onCompleteTaskClick}>Mark as Complete</Button>
-              ) : null}
-            </ButtonGroup>
-          </Stack>
-        </Stack>
-      </Card.Section>
-    </Card>
-  );
-}
-
+/**
+ * This component is shown when a Task has not been selected yet.
+ */
 function EmptyTaskCardBody({ loading }: { loading: boolean }) {
   return (
     <Card sectioned>

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import dynamic from "next/dynamic";
-import { Card, EmptyState, Layout, Spinner } from "@shopify/polaris";
+import { Card, EmptyState, Layout, Spinner, Text } from "@shopify/polaris";
 import { AxiosError } from "axios";
 import styled from "styled-components";
 
@@ -17,23 +17,6 @@ import { OfferCard } from "./OfferCard";
 const TaskCard = dynamic(() =>
   import("./TaskCard").then((mod) => mod.TaskCard)
 );
-
-/**
- * This component is shown when a Task has not been selected yet.
- */
-function EmptyTaskCardBody({ loading }: { loading: boolean }) {
-  return (
-    <Card sectioned>
-      <EmptyState heading="View Task Details Here" image={""}>
-        {loading ? (
-          <Spinner />
-        ) : (
-          <p>Click on the &quot;View Task Details&quot; button.</p>
-        )}
-      </EmptyState>
-    </Card>
-  );
-}
 
 const StyledDiv = styled.div`
   .Polaris-Layout {
@@ -88,11 +71,7 @@ export function ViewOffersPage({ initialOffers }: ViewOffersPageProps) {
     <StyledDiv aria-label="View Offers Page">
       <PageWithNotifications title="Offers" fullWidth>
         <Layout.Section oneHalf>
-          {!selectedTask || loading ? (
-            <EmptyTaskCardBody loading={loading} />
-          ) : (
-            <TaskCard task={selectedTask} />
-          )}
+          <TaskCard task={selectedTask} loading={loading} />
         </Layout.Section>
         <Layout.Section oneHalf>
           {offers.map((offer) => {

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -88,6 +88,13 @@ export function ViewOffersPage({ initialOffers }: ViewOffersPageProps) {
     <StyledDiv aria-label="View Offers Page">
       <PageWithNotifications title="Offers" fullWidth>
         <Layout.Section oneHalf>
+          {!selectedTask || loading ? (
+            <EmptyTaskCardBody loading={loading} />
+          ) : (
+            <TaskCard task={selectedTask} />
+          )}
+        </Layout.Section>
+        <Layout.Section oneHalf>
           {offers.map((offer) => {
             return (
               <OfferCard
@@ -99,13 +106,6 @@ export function ViewOffersPage({ initialOffers }: ViewOffersPageProps) {
               />
             );
           })}
-        </Layout.Section>
-        <Layout.Section oneHalf>
-          {!selectedTask || loading ? (
-            <EmptyTaskCardBody loading={loading} />
-          ) : (
-            <TaskCard task={selectedTask} />
-          )}
         </Layout.Section>
       </PageWithNotifications>
     </StyledDiv>

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -142,12 +142,13 @@ const StyledDiv = styled.div`
 
 export type ViewOffersPageProps = {
   status: "authenticated" | "loading" | "unauthenticated";
+  initialOffers: Offer[];
 };
 
-export function ViewOffersPage({ status }: ViewOffersPageProps) {
+export function ViewOffersPage({ initialOffers, status }: ViewOffersPageProps) {
   const { dispatchNotifications } = useNotifications();
 
-  const [offers, setOffers] = useState(new Array<Offer>());
+  const [offers, setOffers] = useState(initialOffers);
   const [selectedTask, setSelectedTask] = useState<Task | undefined>();
   const [loading, setLoading] = useState(false);
 
@@ -176,34 +177,6 @@ export function ViewOffersPage({ status }: ViewOffersPageProps) {
         setLoading(false);
       });
   };
-
-  useEffect(() => {
-    if (status === "loading") return;
-
-    getOffersOfProviderQuery()
-      .then((offers) => {
-        setOffers(offers);
-      })
-      .catch((error) => {
-        if (error instanceof AxiosError) {
-          const errorMessage =
-            "Failed to load offers. Please contact support if refreshing the page does not work.";
-
-          const apiEvent = createNotification({
-            isError: true,
-            title: errorMessage,
-            type: "notification",
-            status: "warning",
-            source: "Api Error",
-          });
-
-          dispatchNotifications({
-            type: "set",
-            event: apiEvent,
-          });
-        }
-      });
-  }, [dispatchNotifications, status]);
 
   return (
     <StyledDiv aria-label="View Offers Page">

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import dynamic from "next/dynamic";
 import {
   Button,
@@ -24,7 +24,6 @@ import {
 } from "src/common/features/notifications";
 
 import { createNotification } from "src/common/features/notifications/utils";
-import { getOffersOfProviderQuery } from "@Tasks/common/api";
 
 const TaskCard = dynamic(() =>
   import("./TaskCard").then((mod) => mod.TaskCard)
@@ -141,11 +140,10 @@ const StyledDiv = styled.div`
 `;
 
 export type ViewOffersPageProps = {
-  status: "authenticated" | "loading" | "unauthenticated";
   initialOffers: Offer[];
 };
 
-export function ViewOffersPage({ initialOffers, status }: ViewOffersPageProps) {
+export function ViewOffersPage({ initialOffers }: ViewOffersPageProps) {
   const { dispatchNotifications } = useNotifications();
 
   const [offers, setOffers] = useState(initialOffers);

--- a/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
+++ b/src/domains/tasks/ViewOffers/components/ViewOffersPage.tsx
@@ -17,17 +17,14 @@ import styled from "styled-components";
 import { OfferStatusBadge } from "@Tasks/common/components";
 
 import { Offer, Task } from "@Tasks/common/types";
-import {
-  getTaskQuery,
-  getOffersOfProviderQuery,
-  completeOfferMutation,
-} from "../api";
+import { getTaskQuery, completeOfferMutation } from "../api";
 import {
   PageWithNotifications,
   useNotifications,
 } from "src/common/features/notifications";
 
 import { createNotification } from "src/common/features/notifications/utils";
+import { getOffersOfProviderQuery } from "@Tasks/common/api";
 
 const TaskCard = dynamic(() =>
   import("./TaskCard").then((mod) => mod.TaskCard)

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -9,8 +9,9 @@ import {
   InitialNotificationsState,
 } from "src/common/features/notifications";
 
-import { getOffersUrl, getTasksUrl } from "@Tasks/ViewOffers/api";
+import { getTasksUrl } from "@Tasks/ViewOffers/api";
 import userEvent from "@testing-library/user-event";
+import { getOffersUrl } from "@Tasks/common/api";
 
 type setupRenderOptions = {
   componentProps?: ViewOffersPageProps;

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -11,7 +11,6 @@ import {
 
 import { getTasksUrl } from "@Tasks/ViewOffers/api";
 import userEvent from "@testing-library/user-event";
-import { getOffersUrl } from "@Tasks/common/api";
 import { Offer } from "@Tasks/common/types";
 
 type SetupRenderOptions = {
@@ -21,7 +20,6 @@ type SetupRenderOptions = {
 
 const defaultSetupRenderProps: SetupRenderOptions = {
   componentProps: {
-    status: "unauthenticated",
     initialOffers: new Array<Offer>(),
   },
 } as const;
@@ -60,7 +58,6 @@ const getTaskNotFoundHandler = rest.get(
 
 test("smoke test if it renders", async () => {
   const componentProps: ViewOffersPageProps = {
-    status: "authenticated",
     initialOffers: [offer],
   };
 
@@ -74,7 +71,6 @@ test("smoke test if it renders", async () => {
 
 test("displays a list of OfferItems", async () => {
   const componentProps: ViewOffersPageProps = {
-    status: "authenticated",
     initialOffers: [offer, offer],
   };
 
@@ -88,7 +84,6 @@ test("displays a list of OfferItems", async () => {
 
 test("displays error notification when getTaskQuery fails", async () => {
   const componentProps: ViewOffersPageProps = {
-    status: "authenticated",
     initialOffers: [offer],
   };
 

--- a/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
+++ b/src/domains/tasks/ViewOffers/components/test/ViewOffersPage.test.tsx
@@ -12,55 +12,39 @@ import {
 import { getTasksUrl } from "@Tasks/ViewOffers/api";
 import userEvent from "@testing-library/user-event";
 import { getOffersUrl } from "@Tasks/common/api";
+import { Offer } from "@Tasks/common/types";
 
-type setupRenderOptions = {
-  componentProps?: ViewOffersPageProps;
+type SetupRenderOptions = {
+  componentProps: ViewOffersPageProps;
   initialProviderState?: InitialNotificationsState;
 };
+
+const defaultSetupRenderProps: SetupRenderOptions = {
+  componentProps: {
+    status: "unauthenticated",
+    initialOffers: new Array<Offer>(),
+  },
+} as const;
 
 async function setupRender({
   initialProviderState,
   componentProps,
-}: setupRenderOptions = {}) {
+}: SetupRenderOptions = defaultSetupRenderProps) {
   return renderWithPolarisTestProvider(
     <NotificationsProvider initialState={initialProviderState}>
-      <ViewOffersPage
-        status={
-          componentProps?.status ? componentProps.status : "unauthenticated"
-        }
-      />
+      <ViewOffersPage {...componentProps} />
     </NotificationsProvider>
   );
 }
 
-const getOffersSuccessHandler = rest.get(
-  getOffersUrl,
-  async (req, res, ctx) => {
-    const serverResponse = {
-      status: "success",
-      results: 16,
-      data: {
-        offers: [
-          {
-            status: "completed",
-            _id: "6360610f5fac2e5082d00912",
-            offerAmt: 195,
-            comments: "waerawerawerw123123123123123",
-            providerId: "acct_1Lur4rIWxYvLVjGY",
-            task: "636060fa5fac2e5082d00903",
-            createdAt: "2022-10-31T23:58:07.185Z",
-            updatedAt: "2022-11-06T09:28:04.710Z",
-            __v: 0,
-            timeElapsed: "121 days ago",
-            id: "6360610f5fac2e5082d00912",
-          },
-        ],
-      },
-    };
-
-    return res(ctx.status(200), ctx.json(serverResponse));
-  }
-);
+const offer: Offer = {
+  status: "completed",
+  offerAmt: 195,
+  comments: "waerawerawerw123123123123123",
+  providerId: "acct_1Lur4rIWxYvLVjGY",
+  task: "636060fa5fac2e5082d00903",
+  id: "6360610f5fac2e5082d00912",
+};
 
 const getTaskNotFoundHandler = rest.get(
   `${getTasksUrl}/:id`,
@@ -75,7 +59,10 @@ const getTaskNotFoundHandler = rest.get(
 );
 
 test("smoke test if it renders", async () => {
-  const componentProps = { status: "authenticated" } as const;
+  const componentProps: ViewOffersPageProps = {
+    status: "authenticated",
+    initialOffers: [offer],
+  };
 
   await act(() => {
     setupRender({ componentProps });
@@ -85,8 +72,11 @@ test("smoke test if it renders", async () => {
   expect(viewOffersPage).toBeTruthy();
 });
 
-test("loads a list of OfferItems", async () => {
-  const componentProps = { status: "authenticated" } as const;
+test("displays a list of OfferItems", async () => {
+  const componentProps: ViewOffersPageProps = {
+    status: "authenticated",
+    initialOffers: [offer, offer],
+  };
 
   await act(() => {
     setupRender({ componentProps });
@@ -96,29 +86,18 @@ test("loads a list of OfferItems", async () => {
   expect(offerItems.length).toBeGreaterThan(1);
 });
 
-test("displays error notification when getOffersOfProviderQuery fails", async () => {
-  const testErrorMessage = "THIS IS A TEST FAILURE";
-  server.use(
-    rest.get(getOffersUrl, async (req, res, ctx) => {
-      return res(ctx.status(500), ctx.json({ message: testErrorMessage }));
-    })
-  );
-
-  await act(() => {
-    setupRender();
-  });
-
-  const notification = screen.getByText(/^Failed to load offers./i);
-  expect(notification).toBeTruthy();
-});
-
 test("displays error notification when getTaskQuery fails", async () => {
+  const componentProps: ViewOffersPageProps = {
+    status: "authenticated",
+    initialOffers: [offer],
+  };
+
   // overrides the default MSW handlers
-  server.use(getOffersSuccessHandler, getTaskNotFoundHandler);
+  server.use(getTaskNotFoundHandler);
   const user = userEvent.setup();
 
   await act(() => {
-    setupRender();
+    setupRender({ componentProps });
   });
 
   const viewTaskDetailsButton = screen.getByRole("button", {

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -6,3 +6,11 @@ export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
     params: { my_tasks: true },
   });
 };
+
+export async function getTasks(currentPage: number) {
+  const params = { page: currentPage, limit: 6 };
+
+  return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
+    params,
+  });
+}

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosRequestConfig } from "axios";
+import { Offer } from "../types";
 
 export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
   return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
@@ -14,4 +15,14 @@ export async function getTasksQuery(config?: AxiosRequestConfig) {
     ...config,
     params: { page: currentPage, limit: 6 },
   });
+}
+
+export const getOffersUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`;
+
+export async function getOffersOfProviderQuery() {
+  const response = await axios.get(getOffersUrl, {
+    params: { my_offers: true },
+  });
+
+  return response.data.data.offers as Array<Offer>;
 }

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -1,15 +1,37 @@
 import axios, { AxiosError, AxiosRequestConfig } from "axios";
-import { Offer } from "../types";
+import { Offer, Task } from "../types";
 import {
   Notification,
   createNotification,
 } from "src/common/features/notifications";
 
-export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
-  return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
-    ...config,
-    params: { my_tasks: true },
-  });
+export type GetTasksOfCustomerReturnType = Promise<{
+  tasks: Task[];
+  event?: Notification;
+}>;
+
+export const getTasksOfCustomerQuery = (
+  config?: AxiosRequestConfig
+): GetTasksOfCustomerReturnType => {
+  return axios
+    .get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
+      ...config,
+      params: { my_tasks: true },
+    })
+    .then((res) => ({
+      tasks: res.data.data.tasks,
+    }))
+    .catch((err) => {
+      const notification = createNotification({
+        isError: true,
+        title: `Failed to fetch tasks. Please refresh the page. If the problem persists, please contact the administrator at ${process.env.ADMIN_EMAIL}`,
+        type: "notification",
+        status: "critical",
+        source: "Mark Task as Completed Failure",
+      });
+
+      return { tasks: new Array<Task>(), error: notification };
+    });
 };
 
 export async function getTasksQuery(config?: AxiosRequestConfig) {

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -7,9 +7,7 @@ export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
   });
 };
 
-export async function getTasks(currentPage: number) {
-  const params = { page: currentPage, limit: 6 };
-
+export async function getTasksQuery(currentPage: number) {
   return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
     params,
   });

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -34,13 +34,35 @@ export const getTasksOfCustomerQuery = (
     });
 };
 
-export async function getTasksQuery(config?: AxiosRequestConfig) {
+export type GetTasksQueryReturnType = Promise<{
+  tasks: Task[];
+  event?: Notification;
+}>;
+
+export async function getTasksQuery(
+  config?: AxiosRequestConfig
+): GetTasksQueryReturnType {
   const currentPage = 0;
 
-  return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
-    ...config,
-    params: { page: currentPage, limit: 6 },
-  });
+  return axios
+    .get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
+      ...config,
+      params: { page: currentPage, limit: 6 },
+    })
+    .then((res) => ({
+      tasks: res.data.data.tasks,
+    }))
+    .catch((err) => {
+      const notification = createNotification({
+        status: "critical",
+        isError: true,
+        title: `Failed to fetch tasks. Please refresh the page. If the problem persists, please contact the administrator at ${process.env.ADMIN_EMAIL}`,
+        type: "notification",
+        source: "",
+      });
+
+      return { tasks: new Array<Task>(), error: notification };
+    });
 }
 
 export const getOffersUrl = `${process.env.NEXT_PUBLIC_API_URL}api/v1/offers`;

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -7,10 +7,9 @@ export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
   });
 };
 
-export async function getTasksQuery(
-  currentPage: number,
-  config?: AxiosRequestConfig
-) {
+export async function getTasksQuery(config?: AxiosRequestConfig) {
+  const currentPage = 0;
+
   return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
     ...config,
     params: { page: currentPage, limit: 6 },

--- a/src/domains/tasks/common/api/index.ts
+++ b/src/domains/tasks/common/api/index.ts
@@ -7,8 +7,12 @@ export const getTasksOfCustomerQuery = (config?: AxiosRequestConfig) => {
   });
 };
 
-export async function getTasksQuery(currentPage: number) {
+export async function getTasksQuery(
+  currentPage: number,
+  config?: AxiosRequestConfig
+) {
   return axios.get(`${process.env.NEXT_PUBLIC_API_URL}api/v1/tasks`, {
-    params,
+    ...config,
+    params: { page: currentPage, limit: 6 },
   });
 }

--- a/src/mocks/handlers/offers.handler.ts
+++ b/src/mocks/handlers/offers.handler.ts
@@ -1,5 +1,5 @@
 import { rest } from "msw";
-import { getOffersUrl } from "@Tasks/ViewOffers/api";
+import { getOffersUrl } from "@Tasks/common/api";
 
 export const getOffers = rest.get(getOffersUrl, async (req, res, ctx) => {
   const serverResponse = {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -38,27 +38,13 @@ export const getServerSideProps: GetServerSideProps<
     return { props: { tasks: [], status: "unauthenticated" } };
   }
 
-  try {
-    const tasks = await getTasksQuery({
-      headers: {
-        Authorization: `Bearer ${token?.accessToken}`,
-      },
-    }).then((res) => res.data.data.tasks);
+  const response = await getTasksQuery({
+    headers: {
+      Authorization: `Bearer ${token?.accessToken}`,
+    },
+  });
 
-    return {
-      props: { tasks: tasks, status: "authenticated" },
-    };
-  } catch (err: any) {
-    const event = createNotification({
-      status: "critical",
-      isError: true,
-      title: `Failed to fetch tasks. Please refresh the page. If the problem persists, please contact the administrator at ${process.env.ADMIN_EMAIL}`,
-      type: "notification",
-      source: "",
-    });
-
-    return {
-      props: { tasks: [], status: "authenticated", event },
-    };
-  }
+  return {
+    props: { ...response, status: "authenticated" },
+  };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,3 +1,64 @@
-import { ListingsPage } from "@Tasks/ViewListings";
+import { GetServerSideProps } from "next";
+import { getToken } from "next-auth/jwt";
 
-export default ListingsPage;
+import { ListingsPage } from "@Tasks/ViewListings";
+import { getTasksQuery } from "@Tasks/common/api";
+import { Task } from "@Tasks/common/types";
+
+import {
+  Notification,
+  createNotification,
+  useNotifications,
+} from "../common/features/notifications";
+
+export type ListingsRouteProps = {
+  tasks: Task[];
+  status: "authenticated" | "loading" | "unauthenticated";
+  error?: Notification;
+};
+
+export default function ListingsRoute({
+  tasks,
+  status,
+  error,
+}: ListingsRouteProps) {
+  const { dispatchNotifications } = useNotifications();
+
+  if (error) dispatchNotifications({ type: "set", event: error });
+
+  return <ListingsPage initialTasks={tasks} status={status} />;
+}
+
+export const getServerSideProps: GetServerSideProps<
+  ListingsRouteProps
+> = async ({ req, res }) => {
+  const token = await getToken({ req });
+
+  if (!token) {
+    return { props: { tasks: [], status: "unauthenticated" } };
+  }
+
+  try {
+    const tasks = await getTasksQuery({
+      headers: {
+        Authorization: `Bearer ${token?.accessToken}`,
+      },
+    }).then((res) => res.data.data.tasks);
+
+    return {
+      props: { tasks: tasks, status: "authenticated" },
+    };
+  } catch (err: any) {
+    const event = createNotification({
+      status: "critical",
+      isError: true,
+      title: `Failed to fetch tasks. Please refresh the page. If the problem persists, please contact the administrator at ${process.env.ADMIN_EMAIL}`,
+      type: "notification",
+      source: "",
+    });
+
+    return {
+      props: { tasks: [], status: "authenticated", event },
+    };
+  }
+};

--- a/src/pages/offers.tsx
+++ b/src/pages/offers.tsx
@@ -18,7 +18,6 @@ export type OffersRouteProps = {
 };
 
 export default function OffersRoute({
-  status,
   isProvider,
   offers,
   error,
@@ -45,7 +44,7 @@ export default function OffersRoute({
     );
   }
 
-  return <ViewOffersPage initialOffers={offers} status={status} />;
+  return <ViewOffersPage initialOffers={offers} />;
 }
 
 export const getServerSideProps: GetServerSideProps<OffersRouteProps> = async ({

--- a/src/pages/offers.tsx
+++ b/src/pages/offers.tsx
@@ -1,14 +1,33 @@
-import { useSession } from "next-auth/react";
 import { Card, EmptyState, Layout } from "@shopify/polaris";
 import {
+  Notification,
   PageWithNotifications,
+  useNotifications,
 } from "src/common/features/notifications";
 import { ViewOffersPage } from "@Tasks/ViewOffers/components/ViewOffersPage";
+import { GetServerSideProps } from "next";
+import { getToken } from "next-auth/jwt";
+import { Offer } from "@Tasks/common/types";
+import { getOffersOfProviderQuery } from "@Tasks/common/api";
 
-export default function OffersPage() {
-  const { status, data } = useSession();
+export type OffersRouteProps = {
+  status: "authenticated" | "unauthenticated";
+  isProvider: boolean;
+  offers: Offer[];
+  error?: Notification;
+};
 
-  if (data?.user.customerId) {
+export default function OffersRoute({
+  status,
+  isProvider,
+  offers,
+  error,
+}: OffersRouteProps) {
+  const { dispatchNotifications } = useNotifications();
+
+  if (error) dispatchNotifications({ type: "set", event: error });
+
+  if (!isProvider) {
     return (
       <PageWithNotifications title="Offers" fullWidth>
         <Layout>
@@ -26,5 +45,27 @@ export default function OffersPage() {
     );
   }
 
-  return <ViewOffersPage status={status} />;
+  return <ViewOffersPage initialOffers={offers} status={status} />;
 }
+
+export const getServerSideProps: GetServerSideProps<OffersRouteProps> = async ({
+  req,
+  res,
+}) => {
+  const token = await getToken({ req });
+  const isProvider = !!token?.user.providerId;
+
+  if (!token)
+    return { props: { status: "unauthenticated", isProvider, offers: [] } };
+
+  if (!isProvider)
+    return { props: { status: "authenticated", isProvider, offers: [] } };
+
+  const response = await getOffersOfProviderQuery({
+    headers: {
+      Authorization: `Bearer ${token?.accessToken}`,
+    },
+  });
+
+  return { props: { ...response, status: "authenticated", isProvider } };
+};


### PR DESCRIPTION
This pull request moves initial fetch requests to server-side for the `ListingsPage` and the `ViewOffersPage`

Changes:
- replace client-side initial `Tasks` fetch for the `ListingsPage` with fetch in `getServerSideProps`
- replace client-side initial `Offers` fetch for the `ViewOffersPage` with fetch in `getServerSideProps`
- refactor: colocate TaskPage fetch handling into `src/domains/tasks/common/api`
- refactor: simplify implementation for the ViewOffersPage and related components