### PR TITLE
feat: rename Lawn Mowing Task category to Other

### DIFF
--- a/src/domains/tasks/common/types/index.tsx
+++ b/src/domains/tasks/common/types/index.tsx
@@ -21,8 +21,8 @@ export type PaymentStatus = z.infer<typeof PaymentStatusSchema>;
 export const TaskCategorySchema = z.enum([
   "Cleaning",
   "Gardening",
-  "Lawn Mowing",
   "Painting",
+  "Other",
 ] as const);
 
 export const TaskTimeOfArrivalSchema = z.enum([


### PR DESCRIPTION
Rename `Lawn Mowing` Task category to `Other`.

Closes #199

![Screen Shot 2023-04-25 at 20 52 12](https://user-images.githubusercontent.com/8443215/234256027-94279fa3-1f30-42a1-919e-403c614a0091.png)

We can add filtering in the future, but it won't block the launch. We'll park filtering for now.
